### PR TITLE
Improve runtime environment detection using pre-parsing directives

### DIFF
--- a/src/js/background.js
+++ b/src/js/background.js
@@ -29,7 +29,7 @@
 // Not all platforms may have properly declared vAPI.webextFlavor.
 
 if ( vAPI.webextFlavor === undefined ) {
-    vAPI.webextFlavor = { major: 0, soup: new Set([ 'ublock' ]) };
+    vAPI.webextFlavor = { major: 0, soup: new Set([ 'ublock', 'firefox', 'legacy' ]) };
 }
 
 

--- a/src/js/storage.js
+++ b/src/js/storage.js
@@ -916,6 +916,7 @@
     [ 'env_chromium', 'chromium' ],
     [ 'env_edge', 'edge' ],
     [ 'env_firefox', 'firefox' ],
+    [ 'env_legacy', 'legacy' ],
     [ 'env_mobile', 'mobile' ],
     [ 'env_safari', 'safari' ],
     [ 'cap_html_filtering', 'html_filtering' ],


### PR DESCRIPTION
Currently, uBlock Origin for Firefox legacy-based browsers does not apply rules conditioned by `!#if env_firefox` directive, and at the same time applies rules conditioned by `!#if !env_firefox`. The first leads to the fact that some necessary rules may be skipped, which is not quite optimal, although not so critical. But the second ends up that the rules intended only for Chromium-based browsers are applied and break sites (I saw a complaint about this in the wild).

To get rid of these flaws and confusion, I suggest the following:

1. Make uBlock for firefox-legacy have `env_firefox` defined as `true`.
2. Add an additional token `env_legacy` which is `true` only for uBlock for firefox-legacy.

This will allow us to fine-tune filter lists to suit any requirements and will be especially useful for regional lists that agree to support uBlock for firefox-legacy, but would not want to create a separate file just for it.