### PR TITLE
Attempted to extend extension compatibility furthermore

### DIFF
--- a/dist/update/update.template.xml
+++ b/dist/update/update.template.xml
@@ -6,7 +6,7 @@
         <RDF:li>
           <RDF:Description>
             <em:version>{0}</em:version>
-            <!-- Firefox -->
+            <!-- Firefox, Basilisk, Iceweasel-UXP -->
             <em:targetApplication>
               <RDF:Description>
                 <em:id>{{ec8030f7-c20a-464f-9b0e-13a3a9e97384}}</em:id>
@@ -42,7 +42,7 @@
                 <em:updateLink>https://github.com/gorhill/uBlock-for-firefox-legacy/releases/download/firefox-legacy-{0}/uBlock0_{0}.firefox-legacy.xpi</em:updateLink>
               </RDF:Description>
             </em:targetApplication>
-            <!-- Thunderbird -->
+            <!-- Thunderbird, Interlink Mail -->
             <em:targetApplication>
               <RDF:Description>
                 <em:id>{{3550f703-e582-4d05-9a08-453d09bdfdc6}}</em:id>
@@ -56,6 +56,15 @@
               <RDF:Description>
                 <em:id>{{9184b6fe-4a5c-484d-8b4b-efbfccbfb514}}</em:id>
                 <em:minVersion>52.0</em:minVersion>
+                <em:maxVersion>52.*</em:maxVersion>
+                <em:updateLink>https://github.com/gorhill/uBlock-for-firefox-legacy/releases/download/firefox-legacy-{0}/uBlock0_{0}.firefox-legacy.xpi</em:updateLink>
+              </RDF:Description>
+            </em:targetApplication>
+            <!-- Icedove-UXP, possibly Ambassador IRC -->
+            <em:targetApplication>
+              <RDF:Description>
+                <em:id>{{3aa07e56-beb0-47a0-b0cb-c735edd25419}}</em:id>
+                <em:minVersion>31.0</em:minVersion>
                 <em:maxVersion>52.*</em:maxVersion>
                 <em:updateLink>https://github.com/gorhill/uBlock-for-firefox-legacy/releases/download/firefox-legacy-{0}/uBlock0_{0}.firefox-legacy.xpi</em:updateLink>
               </RDF:Description>

--- a/dist/update/update.xml
+++ b/dist/update/update.xml
@@ -6,7 +6,7 @@
         <RDF:li>
           <RDF:Description>
             <em:version>1.16.4.19</em:version>
-            <!-- Firefox -->
+            <!-- Firefox, Basilisk, Iceweasel-UXP -->
             <em:targetApplication>
               <RDF:Description>
                 <em:id>{ec8030f7-c20a-464f-9b0e-13a3a9e97384}</em:id>
@@ -42,7 +42,7 @@
                 <em:updateLink>https://github.com/gorhill/uBlock-for-firefox-legacy/releases/download/firefox-legacy-1.16.4.19/uBlock0_1.16.4.19.firefox-legacy.xpi</em:updateLink>
               </RDF:Description>
             </em:targetApplication>
-            <!-- Thunderbird -->
+            <!-- Thunderbird, Interlink Mail -->
             <em:targetApplication>
               <RDF:Description>
                 <em:id>{3550f703-e582-4d05-9a08-453d09bdfdc6}</em:id>
@@ -56,6 +56,15 @@
               <RDF:Description>
                 <em:id>{9184b6fe-4a5c-484d-8b4b-efbfccbfb514}</em:id>
                 <em:minVersion>52.0</em:minVersion>
+                <em:maxVersion>52.*</em:maxVersion>
+                <em:updateLink>https://github.com/gorhill/uBlock-for-firefox-legacy/releases/download/firefox-legacy-1.16.4.19/uBlock0_1.16.4.19.firefox-legacy.xpi</em:updateLink>
+              </RDF:Description>
+            </em:targetApplication>
+            <!-- Icedove-UXP, possibly Ambassador IRC -->
+            <em:targetApplication>
+              <RDF:Description>
+                <em:id>{3aa07e56-beb0-47a0-b0cb-c735edd25419}</em:id>
+                <em:minVersion>31.0</em:minVersion>
                 <em:maxVersion>52.*</em:maxVersion>
                 <em:updateLink>https://github.com/gorhill/uBlock-for-firefox-legacy/releases/download/firefox-legacy-1.16.4.19/uBlock0_1.16.4.19.firefox-legacy.xpi</em:updateLink>
               </RDF:Description>

--- a/platform/firefox/install.rdf
+++ b/platform/firefox/install.rdf
@@ -17,7 +17,7 @@
         <em:optionsType>2</em:optionsType>
 {localized}
 
-        <!-- Firefox -->
+        <!-- Firefox, Basilisk, Iceweasel-UXP -->
         <em:targetApplication>
             <Description>
                 <em:id>{{ec8030f7-c20a-464f-9b0e-13a3a9e97384}}</em:id>
@@ -53,7 +53,7 @@
             </Description>
         </em:targetApplication>
 
-        <!-- Thunderbird -->
+        <!-- Thunderbird, Interlink Mail -->
         <em:targetApplication>
             <Description>
                 <em:id>{{3550f703-e582-4d05-9a08-453d09bdfdc6}}</em:id>
@@ -70,5 +70,15 @@
                 <em:maxVersion>52.*</em:maxVersion>
             </Description>
         </em:targetApplication>
+        
+        <!-- Icedove-UXP -->
+        <em:targetApplication>
+            <Description>
+                <em:id>{{3aa07e56-beb0-47a0-b0cb-c735edd25419}}</em:id>
+                <em:minVersion>31.0</em:minVersion>
+                <em:maxVersion>52.*</em:maxVersion>
+            </Description>
+        </em:targetApplication>
+        
     </Description>
 </RDF>

--- a/platform/firefox/install.rdf
+++ b/platform/firefox/install.rdf
@@ -71,7 +71,7 @@
             </Description>
         </em:targetApplication>
         
-        <!-- Icedove-UXP (Not supported by Ambassador IRC, despite them using the same GUID) -->
+        <!-- Icedove-UXP, possibly Ambassador IRC -->
         <em:targetApplication>
             <Description>
                 <em:id>{{3aa07e56-beb0-47a0-b0cb-c735edd25419}}</em:id>

--- a/platform/firefox/install.rdf
+++ b/platform/firefox/install.rdf
@@ -71,7 +71,7 @@
             </Description>
         </em:targetApplication>
         
-        <!-- Icedove-UXP -->
+        <!-- Icedove-UXP (Not supported by Ambassador IRC, despite them using the same GUID) -->
         <em:targetApplication>
             <Description>
                 <em:id>{{3aa07e56-beb0-47a0-b0cb-c735edd25419}}</em:id>


### PR DESCRIPTION
Considering the acceptance of #225, I figured I could just as well try to dig up the GUID values of various other projects listed on http://thereisonlyxul.org/, thinking that if they were forks of Firefox 56 or Thunderbird 52, then surely they'd all accept the same uBO versions as Firefox 56 and Thunderbird 52?

I can confirm functionality in Interlink Mail and Basilisk. I could not find any obvious ways to make it installable in Ambassador IRC. I was unable to test with Iceweasel-UXP or Icedove-UXP (It'd take me a bit of work to get GUI access to my RaspPi setup again, plus I'm not excited about interacting with `Hyperbola` stuff after seeing their pretty miserable *uBO-Libre* fork.)