### PR TITLE
Add support for watch-attr, spath, min-text-length and fix parsing AdGuard's rules

### DIFF
--- a/src/js/codemirror/ubo-static-filtering.js
+++ b/src/js/codemirror/ubo-static-filtering.js
@@ -1,7 +1,7 @@
 /*******************************************************************************
 
     uBlock Origin - a browser extension to block requests.
-    Copyright (C) 2018 Raymond Hill
+    Copyright (C) 2018-present Raymond Hill
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -26,7 +26,7 @@
 CodeMirror.defineMode("ubo-static-filtering", function() {
     var reComment1 = /^\s*!/;
     var reComment2 = /^\s*#/;
-    var reExt = /^(\s*[^#]*)(#(?:#|@#|\$#|@\$#|\?#|@\?#))(.+)$/;
+    var reExt = /^(\s*[^#]*)(#@?(?:\$\??|\?)?#)(.+)$/;
     var reNet = /^(.*?)(?:(\$)([^$]+)?)?$/;
     var reNetAllow = /^\s*@@/;
     var lineStyle = null;

--- a/src/js/contentscript.js
+++ b/src/js/contentscript.js
@@ -377,14 +377,10 @@ vAPI.DOMFilterer = (function() {
             }
             this.needle = new RegExp(arg0, arg1);
         }
-        exec(input) {
-            const output = [];
-            for ( const node of input ) {
-                if ( this.needle.test(node.textContent) ) {
-                    output.push(node);
-                }
+        transpose(node, output) {
+            if ( this.needle.test(node.textContent) ) {
+                output.push(node);
             }
-            return output;
         }
     };
 
@@ -392,24 +388,17 @@ vAPI.DOMFilterer = (function() {
         constructor(task) {
             this.pselector = new PSelector(task[1]);
         }
-        exec(input) {
-            const output = [];
-            for ( const node of input ) {
-                if ( this.pselector.test(node) === this.target ) {
-                    output.push(node);
-                }
+        transpose(node, output) {
+            if ( this.pselector.test(node) === this.target ) {
+                output.push(node);
             }
-            return output;
         }
     };
     PSelectorIfTask.prototype.target = true;
 
     const PSelectorIfNotTask = class extends PSelectorIfTask {
-        constructor(task) {
-            super(task);
-            this.target = false;
-        }
     };
+    PSelectorIfNotTask.prototype.target = false;
 
     const PSelectorMatchesCSSTask = class {
         constructor(task) {
@@ -420,46 +409,31 @@ vAPI.DOMFilterer = (function() {
             }
             this.value = new RegExp(arg0, arg1);
         }
-        exec(input) {
-            const output = [];
-            for ( const node of input ) {
-                const style = window.getComputedStyle(node, this.pseudo);
-                if ( style === null ) { return null; } /* FF */
-                if ( this.value.test(style[this.name]) ) {
-                    output.push(node);
-                }
+        transpose(node, output) {
+            const style = window.getComputedStyle(node, this.pseudo);
+            if ( style !== null && this.value.test(style[this.name]) ) {
+                output.push(node);
             }
-            return output;
         }
     };
     PSelectorMatchesCSSTask.prototype.pseudo = null;
 
     const PSelectorMatchesCSSAfterTask = class extends PSelectorMatchesCSSTask {
-        constructor(task) {
-            super(task);
-            this.pseudo = ':after';
-        }
     };
+    PSelectorMatchesCSSAfterTask.prototype.pseudo = ':after';
 
     const PSelectorMatchesCSSBeforeTask = class extends PSelectorMatchesCSSTask {
-        constructor(task) {
-            super(task);
-            this.pseudo = ':before';
-        }
     };
+    PSelectorMatchesCSSBeforeTask.prototype.pseudo = ':before';
 
     const PSelectorMinTextLengthTask = class {
         constructor(task) {
             this.min = task[1];
         }
-        exec(input) {
-            const output = [];
-            for ( const node of input ) {
-                if ( node.textContent.length >= this.min ) {
-                    output.push(node);
-                }
+        transpose(node, output) {
+            if ( node.textContent.length >= this.min ) {
+                output.push(node);
             }
-            return output;
         }
     };
 
@@ -467,20 +441,15 @@ vAPI.DOMFilterer = (function() {
         constructor(task) {
             this.nth = task[1];
         }
-        exec(input) {
-            const output = [];
-            for ( let node of input ) {
-                let nth = this.nth;
-                for (;;) {
-                    node = node.parentElement;
-                    if ( node === null ) { break; }
-                    nth -= 1;
-                    if ( nth !== 0 ) { continue; }
-                    output.push(node);
-                    break;
-                }
+        transpose(node, output) {
+            let nth = this.nth;
+            for (;;) {
+                node = node.parentElement;
+                if ( node === null ) { return; }
+                nth -= 1;
+                if ( nth === 0 ) { break; }
             }
-            return output;
+            output.push(node);
         }
     };
 
@@ -488,25 +457,21 @@ vAPI.DOMFilterer = (function() {
         constructor(task) {
             this.spath = task[1];
         }
-        exec(input) {
-            const output = [];
-            for ( let node of input ) {
-                const parent = node.parentElement;
-                if ( parent === null ) { continue; }
-                let pos = 1;
-                for (;;) {
-                    node = node.previousElementSibling;
-                    if ( node === null ) { break; }
-                    pos += 1;
-                }
-                const nodes = parent.querySelectorAll(
-                    ':scope > :nth-child(' + pos + ')' + this.spath
-                );
-                for ( const node of nodes ) {
-                    output.push(node);
-                }
+        transpose(node, output) {
+            const parent = node.parentElement;
+            if ( parent === null ) { return; }
+            let pos = 1;
+            for (;;) {
+                node = node.previousElementSibling;
+                if ( node === null ) { break; }
+                pos += 1;
             }
-            return output;
+            const nodes = parent.querySelectorAll(
+                `:scope > :nth-child(${pos})${this.spath}`
+            );
+            for ( const node of nodes ) {
+                output.push(node);
+            }
         }
     };
 
@@ -531,17 +496,14 @@ vAPI.DOMFilterer = (function() {
                 filterer.onDOMChanged([ null ]);
             }
         }
-        exec(input) {
-            if ( input.length === 0 ) { return input; }
+        transpose(node, output) {
+            output.push(node);
+            if ( this.observed.has(node) ) { return; }
             if ( this.observer === null ) {
                 this.observer = new MutationObserver(this.handler);
             }
-            for ( const node of input ) {
-                if ( this.observed.has(node) ) { continue; }
-                this.observer.observe(node, this.observerOptions);
-                this.observed.add(node);
-            }
-            return input;
+            this.observer.observe(node, this.observerOptions);
+            this.observed.add(node);
         }
     };
 
@@ -550,23 +512,19 @@ vAPI.DOMFilterer = (function() {
             this.xpe = document.createExpression(task[1], null);
             this.xpr = null;
         }
-        exec(input) {
-            const output = [];
-            for ( const node of input ) {
-                this.xpr = this.xpe.evaluate(
-                    node,
-                    XPathResult.UNORDERED_NODE_SNAPSHOT_TYPE,
-                    this.xpr
-                );
-                let j = this.xpr.snapshotLength;
-                while ( j-- ) {
-                    const node = this.xpr.snapshotItem(j);
-                    if ( node.nodeType === 1 ) {
-                        output.push(node);
-                    }
+        transpose(node, output) {
+            this.xpr = this.xpe.evaluate(
+                node,
+                XPathResult.UNORDERED_NODE_SNAPSHOT_TYPE,
+                this.xpr
+            );
+            let j = this.xpr.snapshotLength;
+            while ( j-- ) {
+                const node = this.xpr.snapshotItem(j);
+                if ( node.nodeType === 1 ) {
+                    output.push(node);
                 }
             }
-            return output;
         }
     };
 
@@ -585,7 +543,7 @@ vAPI.DOMFilterer = (function() {
                     [ ':not', PSelectorIfNotTask ],
                     [ ':nth-ancestor', PSelectorNthAncestorTask ],
                     [ ':spath', PSelectorSpathTask ],
-                    [ ':watch-attrs', PSelectorWatchAttrs ],
+                    [ ':watch-attr', PSelectorWatchAttrs ],
                     [ ':xpath', PSelectorXpathTask ],
                 ]);
             }
@@ -612,21 +570,27 @@ vAPI.DOMFilterer = (function() {
             let nodes = this.prime(input);
             for ( const task of this.tasks ) {
                 if ( nodes.length === 0 ) { break; }
-                nodes = task.exec(nodes);
+                const transposed = [];
+                for ( const node of nodes ) {
+                    task.transpose(node, transposed);
+                }
+                nodes = transposed;
             }
             return nodes;
         }
         test(input) {
             const nodes = this.prime(input);
-            const AA = [ null ];
             for ( const node of nodes ) {
-                AA[0] = node;
-                let aa = AA;
+                let output = [ node ];
                 for ( const task of this.tasks ) {
-                    aa = task.exec(aa);
-                    if ( aa.length === 0 ) { break; }
+                    const transposed = [];
+                    for ( const node of output ) {
+                        task.transpose(node, transposed);
+                    }
+                    output = transposed;
+                    if ( output.length === 0 ) { break; }
                 }
-                if ( aa.length !== 0 ) { return true; }
+                if ( output.length !== 0 ) { return true; }
             }
             return false;
         }

--- a/src/js/contentscript.js
+++ b/src/js/contentscript.js
@@ -767,8 +767,6 @@ vAPI.domFilterer = new vAPI.DOMFilterer();
 
 vAPI.domCollapser = (function() {
     const messaging = vAPI.messaging;
-    const toProcess = [];
-    const toFilter = [];
     const toCollapse = new Map();
     const src1stProps = {
         embed: 'src',
@@ -791,6 +789,8 @@ vAPI.domCollapser = (function() {
         cachedBlockedSet,
         cachedBlockedSetHash,
         cachedBlockedSetTimer,
+        toProcess = [],
+        toFilter = [],
         netSelectorCacheCount = 0;
 
     const cachedBlockedSetClear = function() {
@@ -881,8 +881,8 @@ vAPI.domCollapser = (function() {
             hash: cachedBlockedSetHash
         };
         messaging.send('contentscript', msg, onProcessed);
-        toProcess.length = 0;
-        toFilter.length = 0;
+        toProcess = [];
+        toFilter = [];
         resquestIdGenerator += 1;
     };
 
@@ -944,10 +944,7 @@ vAPI.domCollapser = (function() {
             return;
         }
         if ( src.lastIndexOf('http', 0) !== 0 ) { return; }
-        toFilter[toFilter.length] = {
-            type: 'sub_frame',
-            url: iframe.src
-        };
+        toFilter.push({ type: 'sub_frame', url: iframe.src });
         add(iframe);
     };
 

--- a/src/js/contentscript.js
+++ b/src/js/contentscript.js
@@ -369,217 +369,253 @@ vAPI.DOMFilterer = (function() {
 
     // 'P' stands for 'Procedural'
 
-    const PSelectorHasTextTask = function(task) {
-        let arg0 = task[1], arg1;
-        if ( Array.isArray(task[1]) ) {
-            arg1 = arg0[1]; arg0 = arg0[0];
-        }
-        this.needle = new RegExp(arg0, arg1);
-    };
-    PSelectorHasTextTask.prototype.exec = function(input) {
-        const output = [];
-        for ( const node of input ) {
-            if ( this.needle.test(node.textContent) ) {
-                output.push(node);
+    const PSelectorHasTextTask = class {
+        constructor(task) {
+            let arg0 = task[1], arg1;
+            if ( Array.isArray(task[1]) ) {
+                arg1 = arg0[1]; arg0 = arg0[0];
             }
+            this.needle = new RegExp(arg0, arg1);
         }
-        return output;
-    };
-
-    const PSelectorIfTask = function(task) {
-        this.pselector = new PSelector(task[1]);
-    };
-    PSelectorIfTask.prototype.target = true;
-    PSelectorIfTask.prototype.exec = function(input) {
-        const output = [];
-        for ( const node of input ) {
-            if ( this.pselector.test(node) === this.target ) {
-                output.push(node);
-            }
-        }
-        return output;
-    };
-
-    const PSelectorIfNotTask = function(task) {
-        PSelectorIfTask.call(this, task);
-        this.target = false;
-    };
-    PSelectorIfNotTask.prototype = Object.create(PSelectorIfTask.prototype);
-    PSelectorIfNotTask.prototype.constructor = PSelectorIfNotTask;
-
-    const PSelectorMatchesCSSTask = function(task) {
-        this.name = task[1].name;
-        let arg0 = task[1].value, arg1;
-        if ( Array.isArray(arg0) ) {
-            arg1 = arg0[1]; arg0 = arg0[0];
-        }
-        this.value = new RegExp(arg0, arg1);
-    };
-    PSelectorMatchesCSSTask.prototype.pseudo = null;
-    PSelectorMatchesCSSTask.prototype.exec = function(input) {
-        const output = [];
-        for ( const node of input ) {
-            const style = window.getComputedStyle(node, this.pseudo);
-            if ( style === null ) { return null; } /* FF */
-            if ( this.value.test(style[this.name]) ) {
-                output.push(node);
-            }
-        }
-        return output;
-    };
-
-    const PSelectorMatchesCSSAfterTask = function(task) {
-        PSelectorMatchesCSSTask.call(this, task);
-        this.pseudo = ':after';
-    };
-    PSelectorMatchesCSSAfterTask.prototype = Object.create(PSelectorMatchesCSSTask.prototype);
-    PSelectorMatchesCSSAfterTask.prototype.constructor = PSelectorMatchesCSSAfterTask;
-
-    const PSelectorMatchesCSSBeforeTask = function(task) {
-        PSelectorMatchesCSSTask.call(this, task);
-        this.pseudo = ':before';
-    };
-    PSelectorMatchesCSSBeforeTask.prototype = Object.create(PSelectorMatchesCSSTask.prototype);
-    PSelectorMatchesCSSBeforeTask.prototype.constructor = PSelectorMatchesCSSBeforeTask;
-
-    const PSelectorSpathTask = function(task) {
-        this.spath = task[1];
-    };
-    PSelectorSpathTask.prototype.exec = function(input) {
-        const output = [];
-        for ( let node of input ) {
-            const parent = node.parentElement;
-            if ( parent === null ) { continue; }
-            let pos = 1;
-            for (;;) {
-                node = node.previousElementSibling;
-                if ( node === null ) { break; }
-                pos += 1;
-            }
-            const nodes = parent.querySelectorAll(
-                ':scope > :nth-child(' + pos + ')' + this.spath
-            );
-            for ( const node of nodes ) {
-                output.push(node);
-            }
-        }
-        return output;
-    };
-
-    const PSelectorWatchAttrs = function(task) {
-        this.observer = null;
-        this.observed = new WeakSet();
-        this.observerOptions = {
-            attributes: true,
-            subtree: true,
-        };
-        const attrs = task[1];
-        if ( Array.isArray(attrs) && attrs.length !== 0 ) {
-            this.observerOptions.attributeFilter = task[1];
-        }
-    };
-    // TODO: Is it worth trying to re-apply only the current selector?
-    PSelectorWatchAttrs.prototype.handler = function() {
-        const filterer =
-            vAPI.domFilterer && vAPI.domFilterer.proceduralFilterer;
-        if ( filterer instanceof Object ) {
-            filterer.onDOMChanged([ null ]);
-        }
-    };
-    PSelectorWatchAttrs.prototype.exec = function(input) {
-        if ( input.length === 0 ) { return input; }
-        if ( this.observer === null ) {
-            this.observer = new MutationObserver(this.handler);
-        }
-        for ( const node of input ) {
-            if ( this.observed.has(node) ) { continue; }
-            this.observer.observe(node, this.observerOptions);
-            this.observed.add(node);
-        }
-        return input;
-    };
-
-    const PSelectorXpathTask = function(task) {
-        this.xpe = document.createExpression(task[1], null);
-        this.xpr = null;
-    };
-    PSelectorXpathTask.prototype.exec = function(input) {
-        const output = [];
-        for ( const node of input ) {
-            this.xpr = this.xpe.evaluate(
-                node,
-                XPathResult.UNORDERED_NODE_SNAPSHOT_TYPE,
-                this.xpr
-            );
-            let j = this.xpr.snapshotLength;
-            while ( j-- ) {
-                const node = this.xpr.snapshotItem(j);
-                if ( node.nodeType === 1 ) {
+        exec(input) {
+            const output = [];
+            for ( const node of input ) {
+                if ( this.needle.test(node.textContent) ) {
                     output.push(node);
                 }
             }
+            return output;
         }
-        return output;
     };
 
-    const PSelector = function(o) {
-        if ( PSelector.prototype.operatorToTaskMap === undefined ) {
-            PSelector.prototype.operatorToTaskMap = new Map([
-                [ ':has', PSelectorIfTask ],
-                [ ':has-text', PSelectorHasTextTask ],
-                [ ':if', PSelectorIfTask ],
-                [ ':if-not', PSelectorIfNotTask ],
-                [ ':matches-css', PSelectorMatchesCSSTask ],
-                [ ':matches-css-after', PSelectorMatchesCSSAfterTask ],
-                [ ':matches-css-before', PSelectorMatchesCSSBeforeTask ],
-                [ ':not', PSelectorIfNotTask ],
-                [ ':spath', PSelectorSpathTask ],
-                [ ':watch-attrs', PSelectorWatchAttrs ],
-                [ ':xpath', PSelectorXpathTask ],
-            ]);
+    const PSelectorIfTask = class {
+        constructor(task) {
+            this.pselector = new PSelector(task[1]);
         }
-        this.budget = 200; // I arbitrary picked a 1/5 second
-        this.raw = o.raw;
-        this.cost = 0;
-        this.lastAllowanceTime = 0;
-        this.selector = o.selector;
-        this.tasks = [];
-        const tasks = o.tasks;
-        if ( !tasks ) { return; }
-        for ( const task of tasks ) {
-            this.tasks.push(new (this.operatorToTaskMap.get(task[0]))(task));
+        exec(input) {
+            const output = [];
+            for ( const node of input ) {
+                if ( this.pselector.test(node) === this.target ) {
+                    output.push(node);
+                }
+            }
+            return output;
+        }
+    };
+    PSelectorIfTask.prototype.target = true;
+
+    const PSelectorIfNotTask = class extends PSelectorIfTask {
+        constructor(task) {
+            super(task);
+            this.target = false;
+        }
+    };
+
+    const PSelectorMatchesCSSTask = class {
+        constructor(task) {
+            this.name = task[1].name;
+            let arg0 = task[1].value, arg1;
+            if ( Array.isArray(arg0) ) {
+                arg1 = arg0[1]; arg0 = arg0[0];
+            }
+            this.value = new RegExp(arg0, arg1);
+        }
+        exec(input) {
+            const output = [];
+            for ( const node of input ) {
+                const style = window.getComputedStyle(node, this.pseudo);
+                if ( style === null ) { return null; } /* FF */
+                if ( this.value.test(style[this.name]) ) {
+                    output.push(node);
+                }
+            }
+            return output;
+        }
+    };
+    PSelectorMatchesCSSTask.prototype.pseudo = null;
+
+    const PSelectorMatchesCSSAfterTask = class extends PSelectorMatchesCSSTask {
+        constructor(task) {
+            super(task);
+            this.pseudo = ':after';
+        }
+    };
+
+    const PSelectorMatchesCSSBeforeTask = class extends PSelectorMatchesCSSTask {
+        constructor(task) {
+            super(task);
+            this.pseudo = ':before';
+        }
+    };
+
+    const PSelectorNthAncestorTask = class {
+        constructor(task) {
+            this.nth = task[1];
+        }
+        exec(input) {
+            const output = [];
+            for ( let node of input ) {
+                let nth = this.nth;
+                for (;;) {
+                    node = node.parentElement;
+                    if ( node === null ) { break; }
+                    nth -= 1;
+                    if ( nth !== 0 ) { continue; }
+                    output.push(node);
+                    break;
+                }
+            }
+            return output;
+        }
+    };
+
+    const PSelectorSpathTask = class {
+        constructor(task) {
+            this.spath = task[1];
+        }
+        exec(input) {
+            const output = [];
+            for ( let node of input ) {
+                const parent = node.parentElement;
+                if ( parent === null ) { continue; }
+                let pos = 1;
+                for (;;) {
+                    node = node.previousElementSibling;
+                    if ( node === null ) { break; }
+                    pos += 1;
+                }
+                const nodes = parent.querySelectorAll(
+                    ':scope > :nth-child(' + pos + ')' + this.spath
+                );
+                for ( const node of nodes ) {
+                    output.push(node);
+                }
+            }
+            return output;
+        }
+    };
+
+    const PSelectorWatchAttrs = class {
+        constructor(task) {
+            this.observer = null;
+            this.observed = new WeakSet();
+            this.observerOptions = {
+                attributes: true,
+                subtree: true,
+            };
+            const attrs = task[1];
+            if ( Array.isArray(attrs) && attrs.length !== 0 ) {
+                this.observerOptions.attributeFilter = task[1];
+            }
+        }
+        // TODO: Is it worth trying to re-apply only the current selector?
+        handler() {
+            const filterer =
+                vAPI.domFilterer && vAPI.domFilterer.proceduralFilterer;
+            if ( filterer instanceof Object ) {
+                filterer.onDOMChanged([ null ]);
+            }
+        }
+        exec(input) {
+            if ( input.length === 0 ) { return input; }
+            if ( this.observer === null ) {
+                this.observer = new MutationObserver(this.handler);
+            }
+            for ( const node of input ) {
+                if ( this.observed.has(node) ) { continue; }
+                this.observer.observe(node, this.observerOptions);
+                this.observed.add(node);
+            }
+            return input;
+        }
+    };
+
+    const PSelectorXpathTask = class {
+        constructor(task) {
+            this.xpe = document.createExpression(task[1], null);
+            this.xpr = null;
+        }
+        exec(input) {
+            const output = [];
+            for ( const node of input ) {
+                this.xpr = this.xpe.evaluate(
+                    node,
+                    XPathResult.UNORDERED_NODE_SNAPSHOT_TYPE,
+                    this.xpr
+                );
+                let j = this.xpr.snapshotLength;
+                while ( j-- ) {
+                    const node = this.xpr.snapshotItem(j);
+                    if ( node.nodeType === 1 ) {
+                        output.push(node);
+                    }
+                }
+            }
+            return output;
+        }
+    };
+
+    const PSelector = class {
+        constructor(o) {
+            if ( PSelector.prototype.operatorToTaskMap === undefined ) {
+                PSelector.prototype.operatorToTaskMap = new Map([
+                    [ ':has', PSelectorIfTask ],
+                    [ ':has-text', PSelectorHasTextTask ],
+                    [ ':if', PSelectorIfTask ],
+                    [ ':if-not', PSelectorIfNotTask ],
+                    [ ':matches-css', PSelectorMatchesCSSTask ],
+                    [ ':matches-css-after', PSelectorMatchesCSSAfterTask ],
+                    [ ':matches-css-before', PSelectorMatchesCSSBeforeTask ],
+                    [ ':not', PSelectorIfNotTask ],
+                    [ ':nth-ancestor', PSelectorNthAncestorTask ],
+                    [ ':spath', PSelectorSpathTask ],
+                    [ ':watch-attrs', PSelectorWatchAttrs ],
+                    [ ':xpath', PSelectorXpathTask ],
+                ]);
+            }
+            this.budget = 200; // I arbitrary picked a 1/5 second
+            this.raw = o.raw;
+            this.cost = 0;
+            this.lastAllowanceTime = 0;
+            this.selector = o.selector;
+            this.tasks = [];
+            const tasks = o.tasks;
+            if ( !tasks ) { return; }
+            for ( const task of tasks ) {
+                this.tasks.push(new (this.operatorToTaskMap.get(task[0]))(task));
+            }
+        }
+        prime(input) {
+            const root = input || document;
+            if ( this.selector !== '' ) {
+                return root.querySelectorAll(this.selector);
+            }
+            return [ root ];
+        }
+        exec(input) {
+            let nodes = this.prime(input);
+            for ( const task of this.tasks ) {
+                if ( nodes.length === 0 ) { break; }
+                nodes = task.exec(nodes);
+            }
+            return nodes;
+        }
+        test(input) {
+            const nodes = this.prime(input);
+            const AA = [ null ];
+            for ( const node of nodes ) {
+                AA[0] = node;
+                let aa = AA;
+                for ( const task of this.tasks ) {
+                    aa = task.exec(aa);
+                    if ( aa.length === 0 ) { break; }
+                }
+                if ( aa.length !== 0 ) { return true; }
+            }
+            return false;
         }
     };
     PSelector.prototype.operatorToTaskMap = undefined;
-    PSelector.prototype.prime = function(input) {
-        const root = input || document;
-        if ( this.selector !== '' ) {
-            return root.querySelectorAll(this.selector);
-        }
-        return [ root ];
-    };
-    PSelector.prototype.exec = function(input) {
-        let nodes = this.prime(input);
-        for ( const task of this.tasks ) {
-            if ( nodes.length === 0 ) { break; }
-            nodes = task.exec(nodes);
-        }
-        return nodes;
-    };
-    PSelector.prototype.test = function(input) {
-        const nodes = this.prime(input);
-        const AA = [ null ];
-        for ( const node of nodes ) {
-            AA[0] = node;
-            let aa = AA;
-            for ( const task of this.tasks ) {
-                aa = task.exec(aa);
-                if ( aa.length === 0 ) { break; }
-            }
-            if ( aa.length !== 0 ) { return true; }
-        }
-        return false;
-    };
 
     const DOMProceduralFilterer = function(domFilterer) {
         this.domFilterer = domFilterer;

--- a/src/js/contentscript.js
+++ b/src/js/contentscript.js
@@ -448,6 +448,21 @@ vAPI.DOMFilterer = (function() {
         }
     };
 
+    const PSelectorMinTextLengthTask = class {
+        constructor(task) {
+            this.min = task[1];
+        }
+        exec(input) {
+            const output = [];
+            for ( const node of input ) {
+                if ( node.textContent.length >= this.min ) {
+                    output.push(node);
+                }
+            }
+            return output;
+        }
+    };
+
     const PSelectorNthAncestorTask = class {
         constructor(task) {
             this.nth = task[1];
@@ -566,6 +581,7 @@ vAPI.DOMFilterer = (function() {
                     [ ':matches-css', PSelectorMatchesCSSTask ],
                     [ ':matches-css-after', PSelectorMatchesCSSAfterTask ],
                     [ ':matches-css-before', PSelectorMatchesCSSBeforeTask ],
+                    [ ':min-text-length', PSelectorMinTextLengthTask ],
                     [ ':not', PSelectorIfNotTask ],
                     [ ':nth-ancestor', PSelectorNthAncestorTask ],
                     [ ':spath', PSelectorSpathTask ],

--- a/src/js/contentscript.js
+++ b/src/js/contentscript.js
@@ -1,7 +1,7 @@
 /*******************************************************************************
 
     uBlock Origin - a browser extension to block requests.
-    Copyright (C) 2014-2017 Raymond Hill
+    Copyright (C) 2014-present Raymond Hill
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -105,7 +105,8 @@
 //   https://github.com/chrisaljoudi/uBlock/issues/456
 //   https://github.com/gorhill/uBlock/issues/2029
 
-if ( typeof vAPI === 'object' && !vAPI.contentScript ) { // >>>>>>>> start of HUGE-IF-BLOCK
+ // >>>>>>>> start of HUGE-IF-BLOCK
+if ( typeof vAPI === 'object' && !vAPI.contentScript ) {
 
 /******************************************************************************/
 /******************************************************************************/
@@ -178,28 +179,28 @@ vAPI.SafeAnimationFrame.prototype = {
 
 vAPI.domWatcher = (function() {
 
-    var addedNodeLists = [],
-        addedNodes = [],
-        domIsReady = false,
+    const addedNodeLists = [];
+    const removedNodeLists = [];
+    const addedNodes = [];
+    const ignoreTags = new Set([ 'br', 'head', 'link', 'meta', 'script', 'style' ]);
+    const listeners = [];
+
+    let domIsReady = false,
         domLayoutObserver,
-        ignoreTags = new Set([ 'br', 'head', 'link', 'meta', 'script', 'style' ]),
-        listeners = [],
         listenerIterator = [], listenerIteratorDirty = false,
-        removedNodeLists = [],
         removedNodes = false,
         safeObserverHandlerTimer;
 
-    var safeObserverHandler = function() {
+    const safeObserverHandler = function() {
         //console.time('dom watcher/safe observer handler');
         safeObserverHandlerTimer.clear();
-        var i = addedNodeLists.length,
-            j = addedNodes.length,
-            nodeList, iNode, node;
+        let i = addedNodeLists.length,
+            j = addedNodes.length;
         while ( i-- ) {
-            nodeList = addedNodeLists[i];
-            iNode = nodeList.length;
+            const nodeList = addedNodeLists[i];
+            let iNode = nodeList.length;
             while ( iNode-- ) {
-                node = nodeList[iNode];
+                const node = nodeList[iNode];
                 if ( node.nodeType !== 1 ) { continue; }
                 if ( ignoreTags.has(node.localName) ) { continue; }
                 if ( node.parentElement === null ) { continue; }
@@ -209,8 +210,8 @@ vAPI.domWatcher = (function() {
         addedNodeLists.length = 0;
         i = removedNodeLists.length;
         while ( i-- && removedNodes === false ) {
-            nodeList = removedNodeLists[i];
-            iNode = nodeList.length;
+            const nodeList = removedNodeLists[i];
+            let iNode = nodeList.length;
             while ( iNode-- ) {
                 if ( nodeList[iNode].nodeType !== 1 ) { continue; }
                 removedNodes = true;
@@ -220,7 +221,7 @@ vAPI.domWatcher = (function() {
         removedNodeLists.length = 0;
         //console.timeEnd('dom watcher/safe observer handler');
         if ( addedNodes.length === 0 && removedNodes === false ) { return; }
-        for ( var listener of getListenerIterator() ) {
+        for ( const listener of getListenerIterator() ) {
             listener.onDOMChanged(addedNodes, removedNodes);
         }
         addedNodes.length = 0;
@@ -229,17 +230,15 @@ vAPI.domWatcher = (function() {
 
     // https://github.com/chrisaljoudi/uBlock/issues/205
     // Do not handle added node directly from within mutation observer.
-    var observerHandler = function(mutations) {
+    const observerHandler = function(mutations) {
         //console.time('dom watcher/observer handler');
-        var nodeList, mutation,
-            i = mutations.length;
+        let i = mutations.length;
         while ( i-- ) {
-            mutation = mutations[i];
-            nodeList = mutation.addedNodes;
+            const mutation = mutations[i];
+            let nodeList = mutation.addedNodes;
             if ( nodeList.length !== 0 ) {
                 addedNodeLists.push(nodeList);
             }
-            if ( removedNodes ) { continue; }
             nodeList = mutation.removedNodes;
             if ( nodeList.length !== 0 ) {
                 removedNodeLists.push(nodeList);
@@ -253,7 +252,7 @@ vAPI.domWatcher = (function() {
         //console.timeEnd('dom watcher/observer handler');
     };
 
-    var startMutationObserver = function() {
+    const startMutationObserver = function() {
         if ( domLayoutObserver !== undefined || !domIsReady ) { return; }
         domLayoutObserver = new MutationObserver(observerHandler);
         domLayoutObserver.observe(document.documentElement, {
@@ -266,13 +265,13 @@ vAPI.domWatcher = (function() {
         vAPI.shutdown.add(cleanup);
     };
 
-    var stopMutationObserver = function() {
+    const stopMutationObserver = function() {
         if ( domLayoutObserver === undefined ) { return; }
         cleanup();
         vAPI.shutdown.remove(cleanup);
     };
 
-    var getListenerIterator = function() {
+    const getListenerIterator = function() {
         if ( listenerIteratorDirty ) {
             listenerIterator = listeners.slice();
             listenerIteratorDirty = false;
@@ -280,7 +279,7 @@ vAPI.domWatcher = (function() {
         return listenerIterator;
     };
 
-    var addListener = function(listener) {
+    const addListener = function(listener) {
         if ( listeners.indexOf(listener) !== -1 ) { return; }
         listeners.push(listener);
         listenerIteratorDirty = true;
@@ -289,8 +288,8 @@ vAPI.domWatcher = (function() {
         startMutationObserver();
     };
 
-    var removeListener = function(listener) {
-        var pos = listeners.indexOf(listener);
+    const removeListener = function(listener) {
+        const pos = listeners.indexOf(listener);
         if ( pos === -1 ) { return; }
         listeners.splice(pos, 1);
         listenerIteratorDirty = true;
@@ -299,7 +298,7 @@ vAPI.domWatcher = (function() {
         }
     };
 
-    var cleanup = function() {
+    const cleanup = function() {
         if ( domLayoutObserver !== undefined ) {
             domLayoutObserver.disconnect();
             domLayoutObserver = null;
@@ -310,19 +309,15 @@ vAPI.domWatcher = (function() {
         }
     };
 
-    var start = function() {
+    const start = function() {
         domIsReady = true;
-        for ( var listener of getListenerIterator() ) {
+        for ( const listener of getListenerIterator() ) {
             listener.onDOMCreated();
         }
         startMutationObserver();
     };
 
-    return {
-        start: start,
-        addListener: addListener,
-        removeListener: removeListener
-    };
+    return { start, addListener, removeListener };
 })();
 
 /******************************************************************************/
@@ -330,7 +325,7 @@ vAPI.domWatcher = (function() {
 /******************************************************************************/
 
 vAPI.matchesProp = (function() {
-    var docElem = document.documentElement;
+    const docElem = document.documentElement;
     if ( typeof docElem.matches !== 'function' ) {
         if ( typeof docElem.mozMatchesSelector === 'function' ) {
             return 'mozMatchesSelector';
@@ -447,6 +442,63 @@ vAPI.DOMFilterer = (function() {
     PSelectorMatchesCSSBeforeTask.prototype = Object.create(PSelectorMatchesCSSTask.prototype);
     PSelectorMatchesCSSBeforeTask.prototype.constructor = PSelectorMatchesCSSBeforeTask;
 
+    const PSelectorSpathTask = function(task) {
+        this.spath = task[1];
+    };
+    PSelectorSpathTask.prototype.exec = function(input) {
+        const output = [];
+        for ( let node of input ) {
+            const parent = node.parentElement;
+            if ( parent === null ) { continue; }
+            let pos = 1;
+            for (;;) {
+                node = node.previousElementSibling;
+                if ( node === null ) { break; }
+                pos += 1;
+            }
+            const nodes = parent.querySelectorAll(
+                ':scope > :nth-child(' + pos + ')' + this.spath
+            );
+            for ( const node of nodes ) {
+                output.push(node);
+            }
+        }
+        return output;
+    };
+
+    const PSelectorWatchAttrs = function(task) {
+        this.observer = null;
+        this.observed = new WeakSet();
+        this.observerOptions = {
+            attributes: true,
+            subtree: true,
+        };
+        const attrs = task[1];
+        if ( Array.isArray(attrs) && attrs.length !== 0 ) {
+            this.observerOptions.attributeFilter = task[1];
+        }
+    };
+    // TODO: Is it worth trying to re-apply only the current selector?
+    PSelectorWatchAttrs.prototype.handler = function() {
+        const filterer =
+            vAPI.domFilterer && vAPI.domFilterer.proceduralFilterer;
+        if ( filterer instanceof Object ) {
+            filterer.onDOMChanged([ null ]);
+        }
+    };
+    PSelectorWatchAttrs.prototype.exec = function(input) {
+        if ( input.length === 0 ) { return input; }
+        if ( this.observer === null ) {
+            this.observer = new MutationObserver(this.handler);
+        }
+        for ( const node of input ) {
+            if ( this.observed.has(node) ) { continue; }
+            this.observer.observe(node, this.observerOptions);
+            this.observed.add(node);
+        }
+        return input;
+    };
+
     const PSelectorXpathTask = function(task) {
         this.xpe = document.createExpression(task[1], null);
         this.xpr = null;
@@ -481,7 +533,9 @@ vAPI.DOMFilterer = (function() {
                 [ ':matches-css-after', PSelectorMatchesCSSAfterTask ],
                 [ ':matches-css-before', PSelectorMatchesCSSBeforeTask ],
                 [ ':not', PSelectorIfNotTask ],
-                [ ':xpath', PSelectorXpathTask ]
+                [ ':spath', PSelectorSpathTask ],
+                [ ':watch-attrs', PSelectorWatchAttrs ],
+                [ ':xpath', PSelectorXpathTask ],
             ]);
         }
         this.budget = 200; // I arbitrary picked a 1/5 second
@@ -611,10 +665,9 @@ vAPI.DOMFilterer = (function() {
                     pselector.budget = -0x7FFFFFFF;
                 }
                 t0 = t1;
-                let i = nodes.length;
-                while ( i-- ) {
-                    this.domFilterer.hideNode(nodes[i]);
-                    this.hiddenNodes.add(nodes[i]);
+                for ( const node of nodes ) {
+                    this.domFilterer.hideNode(node);
+                    this.hiddenNodes.add(node);
                 }
             }
 
@@ -713,33 +766,34 @@ vAPI.domFilterer = new vAPI.DOMFilterer();
 /******************************************************************************/
 
 vAPI.domCollapser = (function() {
-    var resquestIdGenerator = 1,
-        processTimer,
-        toProcess = [],
-        toFilter = [],
-        toCollapse = new Map(),
-        cachedBlockedSet,
-        cachedBlockedSetHash,
-        cachedBlockedSetTimer;
-    var src1stProps = {
-        'embed': 'src',
-        'iframe': 'src',
-        'img': 'src',
-        'object': 'data'
+    const messaging = vAPI.messaging;
+    const toProcess = [];
+    const toFilter = [];
+    const toCollapse = new Map();
+    const src1stProps = {
+        embed: 'src',
+        iframe: 'src',
+        img: 'src',
+        object: 'data'
     };
-    var src2ndProps = {
-        'img': 'srcset'
+    const src2ndProps = {
+        img: 'srcset'
     };
-    var tagToTypeMap = {
+    const tagToTypeMap = {
         embed: 'object',
         iframe: 'sub_frame',
         img: 'image',
         object: 'object'
     };
-    var netSelectorCacheCount = 0,
-        messaging = vAPI.messaging;
 
-    var cachedBlockedSetClear = function() {
+    let resquestIdGenerator = 1,
+        processTimer,
+        cachedBlockedSet,
+        cachedBlockedSetHash,
+        cachedBlockedSetTimer,
+        netSelectorCacheCount = 0;
+
+    const cachedBlockedSetClear = function() {
         cachedBlockedSet =
         cachedBlockedSetHash =
         cachedBlockedSetTimer = undefined;
@@ -747,13 +801,13 @@ vAPI.domCollapser = (function() {
 
     // https://github.com/chrisaljoudi/uBlock/issues/174
     //   Do not remove fragment from src URL
-    var onProcessed = function(response) {
+    const onProcessed = function(response) {
         if ( !response ) { // This happens if uBO is disabled or restarted.
             toCollapse.clear();
             return;
         }
 
-        var targets = toCollapse.get(response.id);
+        const targets = toCollapse.get(response.id);
         if ( targets === undefined ) { return; }
         toCollapse.delete(response.id);
         if ( cachedBlockedSetHash !== response.hash ) {
@@ -767,16 +821,15 @@ vAPI.domCollapser = (function() {
         if ( cachedBlockedSet === undefined || cachedBlockedSet.size === 0 ) {
             return;
         }
-        var selectors = [],
-            iframeLoadEventPatch = vAPI.iframeLoadEventPatch,
-            netSelectorCacheCountMax = response.netSelectorCacheCountMax,
-            tag, prop, src, value;
+        const selectors = [];
+        const iframeLoadEventPatch = vAPI.iframeLoadEventPatch;
+        let netSelectorCacheCountMax = response.netSelectorCacheCountMax;
 
-        for ( var target of targets ) {
-            tag = target.localName;
-            prop = src1stProps[tag];
+        for ( const target of targets ) {
+            const tag = target.localName;
+            let prop = src1stProps[tag];
             if ( prop === undefined ) { continue; }
-            src = target[prop];
+            let src = target[prop];
             if ( typeof src !== 'string' || src.length === 0 ) {
                 prop = src2ndProps[tag];
                 if ( prop === undefined ) { continue; }
@@ -792,12 +845,12 @@ vAPI.domCollapser = (function() {
             target.hidden = true;
             // https://github.com/chrisaljoudi/uBlock/issues/1048
             // Use attribute to construct CSS rule
-            if (
-                netSelectorCacheCount <= netSelectorCacheCountMax &&
-                (value = target.getAttribute(prop))
-            ) {
-                selectors.push(tag + '[' + prop + '="' + value + '"]');
-                netSelectorCacheCount += 1;
+            if ( netSelectorCacheCount <= netSelectorCacheCountMax ) {
+                const value = target.getAttribute(prop);
+                if ( value ) {
+                    selectors.push(tag + '[' + prop + '="' + value + '"]');
+                    netSelectorCacheCount += 1;
+                }
             }
             if ( iframeLoadEventPatch !== undefined ) {
                 iframeLoadEventPatch(target);
@@ -817,10 +870,10 @@ vAPI.domCollapser = (function() {
         }
     };
 
-    var send = function() {
+    const send = function() {
         processTimer = undefined;
         toCollapse.set(resquestIdGenerator, toProcess);
-        var msg = {
+        const msg = {
             what: 'getCollapsibleBlockedRequests',
             id: resquestIdGenerator,
             frameURL: window.location.href,
@@ -828,12 +881,12 @@ vAPI.domCollapser = (function() {
             hash: cachedBlockedSetHash
         };
         messaging.send('contentscript', msg, onProcessed);
-        toProcess = [];
-        toFilter = [];
+        toProcess.length = 0;
+        toFilter.length = 0;
         resquestIdGenerator += 1;
     };
 
-    var process = function(delay) {
+    const process = function(delay) {
         if ( toProcess.length === 0 ) { return; }
         if ( delay === 0 ) {
             if ( processTimer !== undefined ) {
@@ -845,31 +898,29 @@ vAPI.domCollapser = (function() {
         }
     };
 
-    var add = function(target) {
+    const add = function(target) {
         toProcess[toProcess.length] = target;
     };
 
-    var addMany = function(targets) {
-        var i = targets.length;
-        while ( i-- ) {
-            add(targets[i]);
+    const addMany = function(targets) {
+        for ( const target of targets ) {
+            add(target);
         }
     };
 
-    var iframeSourceModified = function(mutations) {
-        var i = mutations.length;
-        while ( i-- ) {
-            addIFrame(mutations[i].target, true);
+    const iframeSourceModified = function(mutations) {
+        for ( const mutation of mutations ) {
+            addIFrame(mutation.target, true);
         }
         process();
     };
-    var iframeSourceObserver = new MutationObserver(iframeSourceModified);
-    var iframeSourceObserverOptions = {
+    const iframeSourceObserver = new MutationObserver(iframeSourceModified);
+    const iframeSourceObserverOptions = {
         attributes: true,
         attributeFilter: [ 'src' ]
     };
 
-    var primeLocalIFrame = function(iframe) {
+    const primeLocalIFrame = function(iframe) {
         // Should probably also copy injected styles.
         // The injected scripts are those which were injected in the current
         // document, from within the `contentscript-start.js / injectScripts`,
@@ -880,14 +931,14 @@ vAPI.domCollapser = (function() {
         }
     };
 
-    var addIFrame = function(iframe, dontObserve) {
+    const addIFrame = function(iframe, dontObserve) {
         // https://github.com/gorhill/uBlock/issues/162
         // Be prepared to deal with possible change of src attribute.
         if ( dontObserve !== true ) {
             iframeSourceObserver.observe(iframe, iframeSourceObserverOptions);
         }
 
-        var src = iframe.src;
+        const src = iframe.src;
         if ( src === '' || typeof src !== 'string' ) {
             primeLocalIFrame(iframe);
             return;
@@ -900,21 +951,20 @@ vAPI.domCollapser = (function() {
         add(iframe);
     };
 
-    var addIFrames = function(iframes) {
-        var i = iframes.length;
-        while ( i-- ) {
-            addIFrame(iframes[i]);
+    const addIFrames = function(iframes) {
+        for ( const iframe of iframes ) {
+            addIFrame(iframe);
         }
     };
 
-    var onResourceFailed = function(ev) {
+    const onResourceFailed = function(ev) {
         if ( tagToTypeMap[ev.target.localName] !== undefined ) {
             add(ev.target);
             process();
         }
     };
 
-    var domWatcherInterface = {
+    const domWatcherInterface = {
         onDOMCreated: function() {
             if ( vAPI instanceof Object === false ) { return; }
             if ( vAPI.domCollapser instanceof Object === false ) {
@@ -930,10 +980,9 @@ vAPI.domCollapser = (function() {
             // https://github.com/chrisaljoudi/uBlock/issues/7
             // Preferring getElementsByTagName over querySelectorAll:
             //   http://jsperf.com/queryselectorall-vs-getelementsbytagname/145
-            var elems = document.images || document.getElementsByTagName('img'),
-                i = elems.length, elem;
-            while ( i-- ) {
-                elem = elems[i];
+            const elems = document.images ||
+                          document.getElementsByTagName('img');
+            for ( const elem of elems ) {
                 if ( elem.complete ) {
                     add(elem);
                 }
@@ -953,15 +1002,13 @@ vAPI.domCollapser = (function() {
             });
         },
         onDOMChanged: function(addedNodes) {
-            var ni = addedNodes.length;
-            if ( ni === 0 ) { return; }
-            for ( var i = 0, node; i < ni; i++ ) {
-                node = addedNodes[i];
+            if ( addedNodes.length === 0 ) { return; }
+            for ( const node of addedNodes ) {
                 if ( node.localName === 'iframe' ) {
                     addIFrame(node);
                 }
                 if ( node.childElementCount === 0 ) { continue; }
-                var iframes = node.getElementsByTagName('iframe');
+                const iframes = node.getElementsByTagName('iframe');
                 if ( iframes.length !== 0 ) {
                     addIFrames(iframes);
                 }
@@ -974,13 +1021,7 @@ vAPI.domCollapser = (function() {
         vAPI.domWatcher.addListener(domWatcherInterface);
     }
 
-    return {
-        add: add,
-        addMany: addMany,
-        addIFrame: addIFrame,
-        addIFrames: addIFrames,
-        process: process
-    };
+    return { add, addMany, addIFrame, addIFrames, process };
 })();
 
 /******************************************************************************/
@@ -988,13 +1029,14 @@ vAPI.domCollapser = (function() {
 /******************************************************************************/
 
 vAPI.domSurveyor = (function() {
-    var messaging = vAPI.messaging,
-        domFilterer,
+    const messaging = vAPI.messaging;
+    const queriedIds = new Set();
+    const queriedClasses = new Set();
+    const pendingIdNodes = { nodes: [], added: [] };
+    const pendingClassNodes = { nodes: [], added: [] };
+
+    let domFilterer,
         hostname = '',
-        queriedIds = new Set(),
-        queriedClasses = new Set(),
-        pendingIdNodes = { nodes: [], added: [] },
-        pendingClassNodes = { nodes: [], added: [] },
         surveyCost = 0;
 
     // This is to shutdown the surveyor if result of surveying keeps being
@@ -1002,17 +1044,17 @@ vAPI.domSurveyor = (function() {
     // picked 5 minutes before the surveyor is allowed to shutdown. I also
     // arbitrarily picked 256 misses before the surveyor is allowed to
     // shutdown.
-    var canShutdownAfter = Date.now() + 300000,
+    let canShutdownAfter = Date.now() + 300000,
         surveyingMissCount = 0;
 
     // Handle main process' response.
 
-    var surveyPhase3 = function(response) {
-        var result = response && response.result,
-            mustCommit = false;
+    const surveyPhase3 = function(response) {
+        const result = response && response.result;
+        let mustCommit = false;
 
         if ( result ) {
-            var selectors = result.simple;
+            let selectors = result.simple;
             if ( Array.isArray(selectors) && selectors.length !== 0 ) {
                 domFilterer.addCSSRule(
                     selectors,
@@ -1063,19 +1105,14 @@ vAPI.domSurveyor = (function() {
         vAPI.domSurveyor = null;
     };
 
-    var surveyTimer = new vAPI.SafeAnimationFrame(function() {
-        surveyPhase1();
-    });
-
     // The purpose of "chunkification" is to ensure the surveyor won't unduly
     // block the main event loop.
 
-    var hasChunk = function(pending) {
-        return pending.nodes.length !== 0 ||
-               pending.added.length !== 0;
+    const hasChunk = function(pending) {
+        return pending.nodes.length !== 0 || pending.added.length !== 0;
     };
 
-    var addChunk = function(pending, added) {
+    const addChunk = function(pending, added) {
         if ( added.length === 0 ) { return; }
         if (
             Array.isArray(added) === false ||
@@ -1089,8 +1126,8 @@ vAPI.domSurveyor = (function() {
         }
     };
 
-    var nextChunk = function(pending) {
-        var added = pending.added.length !== 0 ? pending.added.shift() : [],
+    const nextChunk = function(pending) {
+        let added = pending.added.length !== 0 ? pending.added.shift() : [],
             nodes;
         if ( pending.nodes.length === 0 ) {
             if ( added.length <= 1000 ) { return added; }
@@ -1116,39 +1153,39 @@ vAPI.domSurveyor = (function() {
     // Extract all classes/ids: these will be passed to the cosmetic
     // filtering engine, and in return we will obtain only the relevant
     // CSS selectors.
+    const reWhitespace = /\s/;
 
     // https://github.com/gorhill/uBlock/issues/672
     // http://www.w3.org/TR/2014/REC-html5-20141028/infrastructure.html#space-separated-tokens
     // http://jsperf.com/enumerate-classes/6
 
-    var surveyPhase1 = function() {
+    const surveyPhase1 = function() {
         //console.time('dom surveyor/surveying');
         surveyTimer.clear();
-        var t0 = window.performance.now();
-        var rews = reWhitespace,
-            qq, iout, nodes, i, node, v, vv, j;
-        var ids = [];
-        iout = 0;
-        qq = queriedIds;
-        nodes = nextChunk(pendingIdNodes);
-        i = nodes.length;
+        const t0 = window.performance.now();
+        const rews = reWhitespace;
+        const ids = [];
+        let iout = 0;
+        let qq = queriedIds;
+        let nodes = nextChunk(pendingIdNodes);
+        let i = nodes.length;
         while ( i-- ) {
-            node = nodes[i];
-            v = node.id;
+            const node = nodes[i];
+            let v = node.id;
             if ( typeof v !== 'string' ) { continue; }
             v = v.trim();
             if ( qq.has(v) === false && v.length !== 0 ) {
                 ids[iout++] = v; qq.add(v);
             }
         }
-        var classes = [];
+        const classes = [];
         iout = 0;
         qq = queriedClasses;
         nodes = nextChunk(pendingClassNodes);
         i = nodes.length;
         while ( i-- ) {
-            node = nodes[i];
-            vv = node.className;
+            const node = nodes[i];
+            let vv = node.className;
             if ( typeof vv !== 'string' ) { continue; }
             if ( rews.test(vv) === false ) {
                 if ( qq.has(vv) === false && vv.length !== 0 ) {
@@ -1156,9 +1193,9 @@ vAPI.domSurveyor = (function() {
                 }
             } else {
                 vv = node.classList;
-                j = vv.length;
+                let j = vv.length;
                 while ( j-- ) {
-                    v = vv[j];
+                    let v = vv[j];
                     if ( qq.has(v) === false ) {
                         classes[iout++] = v; qq.add(v);
                     }
@@ -1185,9 +1222,10 @@ vAPI.domSurveyor = (function() {
         }
         //console.timeEnd('dom surveyor/surveying');
     };
-    var reWhitespace = /\s/;
 
-    var domWatcherInterface = {
+    const surveyTimer = new vAPI.SafeAnimationFrame(surveyPhase1);
+
+    const domWatcherInterface = {
         onDOMCreated: function() {
             if (
                 vAPI instanceof Object === false ||
@@ -1212,17 +1250,18 @@ vAPI.domSurveyor = (function() {
         onDOMChanged: function(addedNodes) {
             if ( addedNodes.length === 0 ) { return; }
             //console.time('dom surveyor/dom layout changed');
-            var idNodes = [], iid = 0,
-                classNodes = [], iclass = 0;
-            var i = addedNodes.length,
-                node, nodeList, j;
+            const idNodes = [];
+            let iid = 0;
+            const classNodes = [];
+            let iclass = 0;
+            let i = addedNodes.length;
             while ( i-- ) {
-                node = addedNodes[i];
+                const node = addedNodes[i];
                 idNodes[iid++] = node;
                 classNodes[iclass++] = node;
                 if ( node.childElementCount === 0 ) { continue; }
-                nodeList = node.querySelectorAll('[id]');
-                j = nodeList.length;
+                let nodeList = node.querySelectorAll('[id]');
+                let j = nodeList.length;
                 while ( j-- ) {
                     idNodes[iid++] = nodeList[j];
                 }
@@ -1241,15 +1280,13 @@ vAPI.domSurveyor = (function() {
         }
     };
 
-    var start = function(details) {
+    const start = function(details) {
         if ( vAPI.domWatcher instanceof Object === false ) { return; }
         hostname = details.hostname;
         vAPI.domWatcher.addListener(domWatcherInterface);
     };
 
-    return {
-        start: start
-    };
+    return { start };
 })();
 
 /******************************************************************************/
@@ -1261,18 +1298,11 @@ vAPI.domSurveyor = (function() {
 
 (function bootstrap() {
 
-    var bootstrapPhase2 = function(ev) {
+    const bootstrapPhase2 = function() {
         // This can happen on Firefox. For instance:
         // https://github.com/gorhill/uBlock/issues/1893
         if ( window.location === null ) { return; }
-
-        if ( ev ) {
-            document.removeEventListener('DOMContentLoaded', bootstrapPhase2);
-        }
-
-        if ( vAPI instanceof Object === false ) {
-            return;
-        }
+        if ( vAPI instanceof Object === false ) { return; }
 
         if ( vAPI.domWatcher instanceof Object ) {
             vAPI.domWatcher.start();
@@ -1293,8 +1323,8 @@ vAPI.domSurveyor = (function() {
         // as nuisance popups.
         // Ref.: https://developer.mozilla.org/en-US/docs/Web/Events/contextmenu
 
-        var onMouseClick = function(ev) {
-            var elem = ev.target;
+        const onMouseClick = function(ev) {
+            let elem = ev.target;
             while ( elem !== null && elem.localName !== 'a' ) {
                 elem = elem.parentElement;
             }
@@ -1317,9 +1347,9 @@ vAPI.domSurveyor = (function() {
         });
     };
 
-    var bootstrapPhase1 = function(response) {
+    const bootstrapPhase1 = function(response) {
         // cosmetic filtering engine aka 'cfe'
-        var cfeDetails = response && response.specificCosmeticFilters;
+        const cfeDetails = response && response.specificCosmeticFilters;
         if ( !cfeDetails || !cfeDetails.ready ) {
             vAPI.domWatcher = vAPI.domCollapser = vAPI.domFilterer =
             vAPI.domSurveyor = vAPI.domIsLoaded = null;
@@ -1330,7 +1360,7 @@ vAPI.domSurveyor = (function() {
             vAPI.domFilterer = null;
             vAPI.domSurveyor = null;
         } else {
-            var domFilterer = vAPI.domFilterer;
+            const domFilterer = vAPI.domFilterer;
             if ( response.noGenericCosmeticFiltering || cfeDetails.noDOMSurveying ) {
                 vAPI.domSurveyor = null;
             }
@@ -1388,7 +1418,11 @@ vAPI.domSurveyor = (function() {
         ) {
             bootstrapPhase2();
         } else {
-            document.addEventListener('DOMContentLoaded', bootstrapPhase2);
+            document.addEventListener(
+                'DOMContentLoaded',
+                bootstrapPhase2,
+                { once: true }
+            );
         }
     };
 
@@ -1409,4 +1443,5 @@ vAPI.domSurveyor = (function() {
 /******************************************************************************/
 /******************************************************************************/
 
-} // <<<<<<<< end of HUGE-IF-BLOCK
+}
+// <<<<<<<< end of HUGE-IF-BLOCK

--- a/src/js/static-ext-filtering.js
+++ b/src/js/static-ext-filtering.js
@@ -167,6 +167,7 @@
                 'matches-css-after',
                 'matches-css-before',
                 'not',
+                'nth-ancestor',
                 'watch-attrs',
                 'xpath'
                 ].join('|'),
@@ -236,6 +237,13 @@
             }
         };
 
+        const compileNthAncestorSelector = function(s) {
+            const n = parseInt(s, 10);
+            if ( isNaN(n) === false && n >= 1 && n < 256 ) {
+                return n;
+            }
+        };
+
         const compileSpathExpression = function(s) {
             if ( isValidCSSSelector('*' + s) ) {
                 return s;
@@ -278,6 +286,7 @@
             [ ':matches-css-after', compileCSSDeclaration ],
             [ ':matches-css-before', compileCSSDeclaration ],
             [ ':not', compileNotSelector ],
+            [ ':nth-ancestor', compileNthAncestorSelector ],
             [ ':spath', compileSpathExpression ],
             [ ':watch-attrs', compileAttrList ],
             [ ':xpath', compileXpathExpression ]
@@ -301,42 +310,45 @@
                 switch ( task[0] ) {
                 case ':has':
                 case ':if':
-                    raw.push(':has', '(', decompile(task[1]), ')');
+                    raw.push(`:has(${decompile(task[1])})`);
                     break;
                 case ':has-text':
                     if ( Array.isArray(task[1]) ) {
-                        value = '/' + task[1][0] + '/' + task[1][1];
+                        value = `/${task[1][0]}/${task[1][1]}`;
                     } else {
                         value = regexToRawValue.get(task[1]);
                         if ( value === undefined ) {
-                            value = '/' + task[1] + '/';
+                            value = `/${task[1]}/`;
                         }
                     }
-                    raw.push(task[0], '(', value, ')');
+                    raw.push(`:has-text(${value})`);
                     break;
                 case ':matches-css':
                 case ':matches-css-after':
                 case ':matches-css-before':
                     if ( Array.isArray(task[1].value) ) {
-                        value = '/' + task[1].value[0] + '/' + task[1].value[1];
+                        value = `/${task[1].value[0]}/${task[1].value[1]}`;
                     } else {
                         value = regexToRawValue.get(task[1].value);
                         if ( value === undefined ) {
-                            value = '/' + task[1].value + '/';
+                            value = `/${task[1].value}/`;
                         }
                     }
-                    raw.push(task[0], '(', task[1].name, ': ', value, ')');
+                    raw.push(`${task[0]}(${task[1].name}: ${value})`);
                     break;
                 case ':not':
                 case ':if-not':
-                    raw.push(':not', '(', decompile(task[1]), ')');
+                    raw.push(`:not(${decompile(task[1])})`);
+                    break;
+                case ':nth-ancestor':
+                    raw.push(`:nth-ancestor(${task[1]})`);
                     break;
                 case ':spath':
                     raw.push(task[1]);
                     break;
                 case ':watch-attrs':
                 case ':xpath':
-                    raw.push(task[0], '(', task[1], ')');
+                    raw.push(`${task[0]}(${task[1]})`);
                     break;
                 }
             }

--- a/src/js/static-ext-filtering.js
+++ b/src/js/static-ext-filtering.js
@@ -678,11 +678,22 @@
             if ( rpos === -1 ) { return false; }
         }
 
+        // https://github.com/AdguardTeam/AdguardFilters/commit/4fe02d73cee6
+        //   AdGuard also uses `$?` to force inline-based style rather than
+        //   stylesheet-based style.
         // Coarse-check that the anchor is valid.
-        // `##`: l = 1
-        // `#@#`, `#$#`, `#%#`, `#?#`: l = 2
-        // `#@$#`, `#@%#`, `#@?#`: l = 3
-        if ( (rpos - lpos) > 3 ) { return false; }
+        // `##`: l === 1
+        // `#@#`, `#$#`, `#%#`, `#?#`: l === 2
+        // `#@$#`, `#@%#`, `#@?#`, `#$?#`: l === 3
+        // `#@$?#`: l === 4
+        const anchorLen = rpos - lpos;
+        if ( anchorLen > 4 ) { return false; }
+        if (
+            anchorLen > 1 &&
+            /^@?(?:\$\??|%|\?)$/.test(raw.slice(lpos + 1, rpos)) === false
+        ) {
+            return false;
+        }
 
         // Extract the selector.
         let suffix = raw.slice(rpos + 1).trim();
@@ -700,9 +711,8 @@
         if ( cCode !== 0x23 /* '#' */ && cCode !== 0x40 /* '@' */ ) {
             // Adguard's scriptlet injection: not supported.
             if ( cCode === 0x25 /* '%' */ ) { return true; }
-            // Not a known extended filter.
-            if ( cCode !== 0x24 /* '$' */ && cCode !== 0x3F /* '?' */ ) {
-                return false;
+            if ( cCode === 0x3F /* '?' */ && anchorLen > 2 ) {
+                cCode = raw.charCodeAt(rpos - 2);
             }
             // Adguard's style injection: translate to uBO's format.
             if ( cCode === 0x24 /* '$' */ ) {

--- a/src/js/static-ext-filtering.js
+++ b/src/js/static-ext-filtering.js
@@ -160,6 +160,7 @@
                 'matches-css-after',
                 'matches-css-before',
                 'not',
+                'watch-attrs',
                 'xpath'
                 ].join('|'),
             ')\\('
@@ -228,6 +229,23 @@
             }
         };
 
+        const compileSpathExpression = function(s) {
+            if ( isValidCSSSelector('*' + s) ) {
+                return s;
+            }
+        };
+
+        const compileAttrList = function(s) {
+            const attrs = s.split('\s*,\s*');
+            const out = [];
+            for ( const attr of attrs ) {
+                if ( attr !== '' ) {
+                    out.push(attr);
+                }
+            }
+            return out;
+        };
+
         const compileXpathExpression = function(s) {
             try {
                 document.createExpression(s, null);
@@ -253,6 +271,8 @@
             [ ':matches-css-after', compileCSSDeclaration ],
             [ ':matches-css-before', compileCSSDeclaration ],
             [ ':not', compileNotSelector ],
+            [ ':spath', compileSpathExpression ],
+            [ ':watch-attrs', compileAttrList ],
             [ ':xpath', compileXpathExpression ]
         ]);
 
@@ -270,10 +290,11 @@
             }
             const raw = [ compiled.selector ];
             let value;
-            for ( let task of tasks ) {
+            for ( const task of tasks ) {
                 switch ( task[0] ) {
-                case ':xpath':
-                    raw.push(task[0], '(', task[1], ')');
+                case ':has':
+                case ':if':
+                    raw.push(':has', '(', decompile(task[1]), ')');
                     break;
                 case ':has-text':
                     if ( Array.isArray(task[1]) ) {
@@ -299,13 +320,14 @@
                     }
                     raw.push(task[0], '(', task[1].name, ': ', value, ')');
                     break;
-                case ':has':
-                case ':if':
-                    raw.push(':has', '(', decompile(task[1]), ')');
-                    break;
-                case ':if-not':
                 case ':not':
+                case ':if-not':
                     raw.push(':not', '(', decompile(task[1]), ')');
+                    break;
+                case ':spath':
+                case ':watch-attrs':
+                case ':xpath':
+                    raw.push(task[0], '(', task[1], ')');
                     break;
                 }
             }
@@ -357,13 +379,7 @@
                 //   then consider it to be part of the prefix. If there is
                 //   at least one task present, then we fail, as we do not
                 //   support suffix CSS selectors.
-                // TODO: AdGuard does support suffix CSS selectors, so
-                //       supporting this would increase compatibility with
-                //       AdGuard filter lists.
-                if ( isValidCSSSelector(raw.slice(opNameBeg, i)) ) {
-                    if ( opPrefixBeg !== 0 ) { return; }
-                    continue;
-                }
+                if ( isValidCSSSelector(raw.slice(opNameBeg, i)) ) { continue; }
                 // Extract and remember operator details.
                 let operator = raw.slice(opNameBeg, opNameEnd);
                 operator = normalizedOperators.get(operator) || operator;
@@ -373,7 +389,11 @@
                 if ( opPrefixBeg === 0 ) {
                     prefix = raw.slice(0, opNameBeg);
                 } else if ( opNameBeg !== opPrefixBeg ) {
-                    return;
+                    const spath = compileSpathExpression(
+                        raw.slice(opPrefixBeg, opNameBeg)
+                    );
+                    if ( spath === undefined ) { return; }
+                    tasks.push([ ':spath', spath ]);
                 }
                 tasks.push([ operator, args ]);
                 opPrefixBeg = i;
@@ -385,7 +405,9 @@
                 prefix = raw;
                 tasks = undefined;
             } else if ( opPrefixBeg < n ) {
-                return;
+                const spath = compileSpathExpression(raw.slice(opPrefixBeg));
+                if ( spath === undefined ) { return; }
+                tasks.push([ ':spath', spath ]);
             }
             // https://github.com/NanoAdblocker/NanoCore/issues/1#issuecomment-354394894
             if ( prefix !== '' ) {
@@ -400,7 +422,7 @@
                 return lastProceduralSelectorCompiled;
             }
             lastProceduralSelector = raw;
-            var compiled = compile(raw);
+            let compiled = compile(raw);
             if ( compiled !== undefined ) {
                 compiled.raw = decompile(compiled);
                 compiled = JSON.stringify(compiled);

--- a/src/js/static-ext-filtering.js
+++ b/src/js/static-ext-filtering.js
@@ -325,6 +325,8 @@
                     raw.push(':not', '(', decompile(task[1]), ')');
                     break;
                 case ':spath':
+                    raw.push(task[1]);
+                    break;
                 case ':watch-attrs':
                 case ':xpath':
                     raw.push(task[0], '(', task[1], ')');

--- a/src/js/static-ext-filtering.js
+++ b/src/js/static-ext-filtering.js
@@ -119,9 +119,16 @@
     };
 
     const translateAdguardCSSInjectionFilter = function(suffix) {
-        var matches = /^([^{]+)\{([^}]+)\}$/.exec(suffix);
+        const matches = /^([^{]+)\{([^}]+)\}$/.exec(suffix);
         if ( matches === null ) { return ''; }
-        return matches[1].trim() + ':style(' +  matches[2].trim() + ')';
+        const selector = matches[1].trim();
+        const style = matches[2].trim();
+        // For some reasons, many of Adguard's plain cosmetic filters are
+        // "disguised" as style-based cosmetic filters: convert such filters
+        // to plain cosmetic filters.
+        return /display\s*:\s*none\s*!important;?$/.test(style)
+            ? selector
+            : selector + ':style(' +  style + ')';
     };
 
     const hostnamesFromPrefix = function(s) {

--- a/src/js/static-ext-filtering.js
+++ b/src/js/static-ext-filtering.js
@@ -690,7 +690,7 @@
         if ( anchorLen > 4 ) { return false; }
         if (
             anchorLen > 1 &&
-            /^@?(?:\$\??|%|\?)$/.test(raw.slice(lpos + 1, rpos)) === false
+            /^@?(?:\$\??|%|\?)?$/.test(raw.slice(lpos + 1, rpos)) === false
         ) {
             return false;
         }

--- a/src/js/static-ext-filtering.js
+++ b/src/js/static-ext-filtering.js
@@ -169,6 +169,7 @@
                 'min-text-length',
                 'not',
                 'nth-ancestor',
+                'watch-attr',
                 'watch-attrs',
                 'xpath'
                 ].join('|'),
@@ -281,6 +282,7 @@
             [ ':-abp-contains', ':has-text' ],
             [ ':-abp-has', ':has' ],
             [ ':contains', ':has-text' ],
+            [ ':watch-attrs', ':watch-attr' ],
         ]);
 
         const compileArgument = new Map([
@@ -295,7 +297,7 @@
             [ ':not', compileNotSelector ],
             [ ':nth-ancestor', compileNthAncestorSelector ],
             [ ':spath', compileSpathExpression ],
-            [ ':watch-attrs', compileAttrList ],
+            [ ':watch-attr', compileAttrList ],
             [ ':xpath', compileXpathExpression ]
         ]);
 
@@ -352,7 +354,7 @@
                     break;
                 case ':min-text-length':
                 case ':nth-ancestor':
-                case ':watch-attrs':
+                case ':watch-attr':
                 case ':xpath':
                     raw.push(`${task[0]}(${task[1]})`);
                     break;

--- a/src/js/static-ext-filtering.js
+++ b/src/js/static-ext-filtering.js
@@ -166,6 +166,7 @@
                 'matches-css',
                 'matches-css-after',
                 'matches-css-before',
+                'min-text-length',
                 'not',
                 'nth-ancestor',
                 'watch-attrs',
@@ -227,6 +228,14 @@
             return compile(s);
         };
 
+        const compileInteger = function(s, min = 0, max = 0x7FFFFFFF) {
+            if ( /^\d+$/.test(s) === false ) { return; }
+            const n = parseInt(s, 10);
+            if ( n >= min && n < max ) {
+                return n;
+            }
+        };
+
         const compileNotSelector = function(s) {
             // https://github.com/uBlockOrigin/uBlock-issues/issues/341#issuecomment-447603588
             //   Reject instances of :not() filters for which the argument is
@@ -238,10 +247,7 @@
         };
 
         const compileNthAncestorSelector = function(s) {
-            const n = parseInt(s, 10);
-            if ( isNaN(n) === false && n >= 1 && n < 256 ) {
-                return n;
-            }
+            return compileInteger(s, 1, 256);
         };
 
         const compileSpathExpression = function(s) {
@@ -285,6 +291,7 @@
             [ ':matches-css', compileCSSDeclaration ],
             [ ':matches-css-after', compileCSSDeclaration ],
             [ ':matches-css-before', compileCSSDeclaration ],
+            [ ':min-text-length', compileInteger ],
             [ ':not', compileNotSelector ],
             [ ':nth-ancestor', compileNthAncestorSelector ],
             [ ':spath', compileSpathExpression ],
@@ -340,12 +347,11 @@
                 case ':if-not':
                     raw.push(`:not(${decompile(task[1])})`);
                     break;
-                case ':nth-ancestor':
-                    raw.push(`:nth-ancestor(${task[1]})`);
-                    break;
                 case ':spath':
                     raw.push(task[1]);
                     break;
+                case ':min-text-length':
+                case ':nth-ancestor':
                 case ':watch-attrs':
                 case ':xpath':
                     raw.push(`${task[0]}(${task[1]})`);


### PR DESCRIPTION
![2020-07-04_13-47](https://user-images.githubusercontent.com/19818572/86511823-e6cfae80-bdfc-11ea-90e6-76a44cca9065.png)

I skipped changes for html filtering. 

Now should be more green, so fixing `use of sibling-related CSS syntax at prefix position` and adding `remove` and proper `upward` only left. As you can see looks like that all should be good, but maybe will be good to test that again with more „real" examples.