### PR TITLE
fix gorhill/uBlock#2179

### DIFF
--- a/src/_locales/ar/messages.json
+++ b/src/_locales/ar/messages.json
@@ -608,8 +608,12 @@
     "description": "Used in the static filtering wizard"
   },
   "loggerStaticFilteringFinderSentence1": {
-    "message": "فلتر ثابت {{filter}} موجود على:",
-    "description": "Below this sentence, the filter lists in which the filter was found"
+    "message": "فلتر ثابت <code>{{filter}}</code> موجود على:",
+    "description": "Below this sentence, the filter list(s) in which the filter was found"
+  },
+  "loggerStaticFilteringFinderSentence2": {
+    "message": "الفلتر <code>{{filter}}</code> لا يوجد في أي من قوائم الفلاتر المفعلة",
+    "description": "Message to show when a filter cannot be found in any filter lists"
   },
   "aboutChangelog": {
     "message": "سجل التغيير",

--- a/src/_locales/bg/messages.json
+++ b/src/_locales/bg/messages.json
@@ -608,8 +608,12 @@
     "description": "Used in the static filtering wizard"
   },
   "loggerStaticFilteringFinderSentence1": {
-    "message": "Статичният филтър {{filter}} е намерен в:",
-    "description": "Below this sentence, the filter lists in which the filter was found"
+    "message": "Статичният филтър <code>{{filter}}</code> е намерен в:",
+    "description": "Below this sentence, the filter list(s) in which the filter was found"
+  },
+  "loggerStaticFilteringFinderSentence2": {
+    "message": "Статичният филтър не е намерен в никой от активните списъци с филтри",
+    "description": "Message to show when a filter cannot be found in any filter lists"
   },
   "aboutChangelog": {
     "message": "Списък с промени",

--- a/src/_locales/bn/messages.json
+++ b/src/_locales/bn/messages.json
@@ -608,8 +608,12 @@
     "description": "Used in the static filtering wizard"
   },
   "loggerStaticFilteringFinderSentence1": {
-    "message": "স্থির ফিল্টার {{filter}} পাওয়া গেছে:",
-    "description": "Below this sentence, the filter lists in which the filter was found"
+    "message": "স্থির ফিল্টার <code>{{filter}}</code> পাওয়া গেছে:",
+    "description": "Below this sentence, the filter list(s) in which the filter was found"
+  },
+  "loggerStaticFilteringFinderSentence2": {
+    "message": "স্থির ফিল্টার বর্তমানে সক্রিয় ফিল্টার তালিকার কোনটিতে পাওয়া যায় নি",
+    "description": "Message to show when a filter cannot be found in any filter lists"
   },
   "aboutChangelog": {
     "message": "পরিবর্তন লগ",

--- a/src/_locales/ca/messages.json
+++ b/src/_locales/ca/messages.json
@@ -608,8 +608,12 @@
     "description": "Used in the static filtering wizard"
   },
   "loggerStaticFilteringFinderSentence1": {
-    "message": "S'ha trobat el filtre estàtic {{filter}} a:",
-    "description": "Below this sentence, the filter lists in which the filter was found"
+    "message": "S'ha trobat el filtre estàtic <code>{{filter}}</code> a:",
+    "description": "Below this sentence, the filter list(s) in which the filter was found"
+  },
+  "loggerStaticFilteringFinderSentence2": {
+    "message": "No s'ha pogut trobar el filtre estàtic <code>{{filter}}</code> en cap de les llistes de filtres actualment activades",
+    "description": "Message to show when a filter cannot be found in any filter lists"
   },
   "aboutChangelog": {
     "message": "Registre de canvis",

--- a/src/_locales/cs/messages.json
+++ b/src/_locales/cs/messages.json
@@ -608,8 +608,12 @@
     "description": "Used in the static filtering wizard"
   },
   "loggerStaticFilteringFinderSentence1": {
-    "message": "Statický filtr {{filter}} nalezen v seznamech:",
-    "description": "Below this sentence, the filter lists in which the filter was found"
+    "message": "Statický filtr <code>{{filter}}</code> nalezen v seznamech:",
+    "description": "Below this sentence, the filter list(s) in which the filter was found"
+  },
+  "loggerStaticFilteringFinderSentence2": {
+    "message": "Statický filtr <code>{{filter}}</code> nebyl nalezen v žádném aktuálně povoleném seznamu filtrů",
+    "description": "Message to show when a filter cannot be found in any filter lists"
   },
   "aboutChangelog": {
     "message": "Change log",

--- a/src/_locales/cv/messages.json
+++ b/src/_locales/cv/messages.json
@@ -608,8 +608,12 @@
     "description": "Used in the static filtering wizard"
   },
   "loggerStaticFilteringFinderSentence1": {
-    "message": "Static filter {{filter}} found in:",
-    "description": "Below this sentence, the filter lists in which the filter was found"
+    "message": "Static filter <code>{{filter}}</code> found in:",
+    "description": "Below this sentence, the filter list(s) in which the filter was found"
+  },
+  "loggerStaticFilteringFinderSentence2": {
+    "message": "Static filter could not be found in any of the currently enabled filter lists",
+    "description": "Message to show when a filter cannot be found in any filter lists"
   },
   "aboutChangelog": {
     "message": "Улшӑнусен йышӗ",

--- a/src/_locales/da/messages.json
+++ b/src/_locales/da/messages.json
@@ -608,8 +608,12 @@
     "description": "Used in the static filtering wizard"
   },
   "loggerStaticFilteringFinderSentence1": {
-    "message": "Statisk filter {{filter}} findes i:",
-    "description": "Below this sentence, the filter lists in which the filter was found"
+    "message": "Statisk filter <code>{{filter}}</code> fundet i:",
+    "description": "Below this sentence, the filter list(s) in which the filter was found"
+  },
+  "loggerStaticFilteringFinderSentence2": {
+    "message": "Statisk filter kunne ikke findes i nogen af de aktuelt aktiverede filterlister",
+    "description": "Message to show when a filter cannot be found in any filter lists"
   },
   "aboutChangelog": {
     "message": "Ændringslog",

--- a/src/_locales/de/messages.json
+++ b/src/_locales/de/messages.json
@@ -608,8 +608,12 @@
     "description": "Used in the static filtering wizard"
   },
   "loggerStaticFilteringFinderSentence1": {
-    "message": "Statischer Filter {{filter}} gefunden in:",
-    "description": "Below this sentence, the filter lists in which the filter was found"
+    "message": "Statischer Filter <code>{{filter}}</code> gefunden in:",
+    "description": "Below this sentence, the filter list(s) in which the filter was found"
+  },
+  "loggerStaticFilteringFinderSentence2": {
+    "message": "Statischer Filter <code>{{filter}}</code> konnte in keiner der aktuell aktivierten Filterlisten gefunden werden.",
+    "description": "Message to show when a filter cannot be found in any filter lists"
   },
   "aboutChangelog": {
     "message": "Änderungsprotokoll",

--- a/src/_locales/el/messages.json
+++ b/src/_locales/el/messages.json
@@ -608,8 +608,12 @@
     "description": "Used in the static filtering wizard"
   },
   "loggerStaticFilteringFinderSentence1": {
-    "message": "Στατικό φίλτρο {{filter}} βρέθηκε σε:",
-    "description": "Below this sentence, the filter lists in which the filter was found"
+    "message": "Στατικό φίλτρο <code>{{filter}}</code> βρέθηκε σε:",
+    "description": "Below this sentence, the filter list(s) in which the filter was found"
+  },
+  "loggerStaticFilteringFinderSentence2": {
+    "message": "Το στατικό φίλτρo <code>{{filter}}</code> δεν βρέθηκε σε καμία από τις λίστες φίλτρων που έχουν ενεργοποιηθεί αυτήν τη στιγμή",
+    "description": "Message to show when a filter cannot be found in any filter lists"
   },
   "aboutChangelog": {
     "message": "Αρχείο καταγραφής αλλαγών",

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -608,8 +608,12 @@
     "description": "Used in the static filtering wizard"
   },
   "loggerStaticFilteringFinderSentence1": {
-    "message": "Static filter {{filter}} found in:",
-    "description": "Below this sentence, the filter lists in which the filter was found"
+    "message": "Static filter <code>{{filter}}</code> found in:",
+    "description": "Below this sentence, the filter list(s) in which the filter was found"
+  },
+  "loggerStaticFilteringFinderSentence2": {
+    "message": "Static filter could not be found in any of the currently enabled filter lists",
+    "description": "Message to show when a filter cannot be found in any filter lists"
   },
   "aboutChangelog": {
     "message": "Change log",

--- a/src/_locales/eo/messages.json
+++ b/src/_locales/eo/messages.json
@@ -608,8 +608,12 @@
     "description": "Used in the static filtering wizard"
   },
   "loggerStaticFilteringFinderSentence1": {
-    "message": "Statika filtrilo {{filter}} estas trovita en:",
-    "description": "Below this sentence, the filter lists in which the filter was found"
+    "message": "Statika filtrilo <code>{{filter}}</code> estas trovita en:",
+    "description": "Below this sentence, the filter list(s) in which the filter was found"
+  },
+  "loggerStaticFilteringFinderSentence2": {
+    "message": "Static filter could not be found in any of the currently enabled filter lists",
+    "description": "Message to show when a filter cannot be found in any filter lists"
   },
   "aboutChangelog": {
     "message": "Ŝanĝoprotokolo",

--- a/src/_locales/es/messages.json
+++ b/src/_locales/es/messages.json
@@ -609,7 +609,11 @@
   },
   "loggerStaticFilteringFinderSentence1": {
     "message": "Filtro estático <code>{{filter}}</code> encontrado en:",
-    "description": "Below this sentence, the filter lists in which the filter was found"
+    "description": "Below this sentence, the filter list(s) in which the filter was found"
+  },
+  "loggerStaticFilteringFinderSentence2": {
+    "message": "No se pudo encontrar el filtro estático en ninguna de las listas de filtros actualmente habilitadas",
+    "description": "Message to show when a filter cannot be found in any filter lists"
   },
   "aboutChangelog": {
     "message": "Registro de cambios",

--- a/src/_locales/et/messages.json
+++ b/src/_locales/et/messages.json
@@ -608,8 +608,12 @@
     "description": "Used in the static filtering wizard"
   },
   "loggerStaticFilteringFinderSentence1": {
-    "message": "Staatiline filter {{filter}} asub:",
-    "description": "Below this sentence, the filter lists in which the filter was found"
+    "message": "Staatiline filter <code>{{filter}}</code> asub:",
+    "description": "Below this sentence, the filter list(s) in which the filter was found"
+  },
+  "loggerStaticFilteringFinderSentence2": {
+    "message": "Staatilist filtrit ei leitud ühegi hetkel lubatud filtrite loendist",
+    "description": "Message to show when a filter cannot be found in any filter lists"
   },
   "aboutChangelog": {
     "message": "Muudatuste logi",

--- a/src/_locales/eu/messages.json
+++ b/src/_locales/eu/messages.json
@@ -608,8 +608,12 @@
     "description": "Used in the static filtering wizard"
   },
   "loggerStaticFilteringFinderSentence1": {
-    "message": "{{filter}} iragazki estatiko aurkitu da hemen:",
-    "description": "Below this sentence, the filter lists in which the filter was found"
+    "message": "<code>{{filter}}</code> iragazki estatikoa aurkitu da hemen:",
+    "description": "Below this sentence, the filter list(s) in which the filter was found"
+  },
+  "loggerStaticFilteringFinderSentence2": {
+    "message": "<code>{{filter}}</code> iragazki estatikoa ezin izan da aurkitu orain aktibatutako iragazki zerrendetan",
+    "description": "Message to show when a filter cannot be found in any filter lists"
   },
   "aboutChangelog": {
     "message": "Aldaketa egunkaria",

--- a/src/_locales/fa/messages.json
+++ b/src/_locales/fa/messages.json
@@ -608,8 +608,12 @@
     "description": "Used in the static filtering wizard"
   },
   "loggerStaticFilteringFinderSentence1": {
-    "message": "انسداد ایستا {{filter}} یافت شد در:",
-    "description": "Below this sentence, the filter lists in which the filter was found"
+    "message": "انسداد ایستا <code>{{filter}}</code> یافت شد در:",
+    "description": "Below this sentence, the filter list(s) in which the filter was found"
+  },
+  "loggerStaticFilteringFinderSentence2": {
+    "message": "فیلتر ایستا <code>{{filter}}</code> در هیچ یک از لیست‌های فیلتر فعال پیدا نشد",
+    "description": "Message to show when a filter cannot be found in any filter lists"
   },
   "aboutChangelog": {
     "message": "تغییرات اخیر",

--- a/src/_locales/fi/messages.json
+++ b/src/_locales/fi/messages.json
@@ -608,8 +608,12 @@
     "description": "Used in the static filtering wizard"
   },
   "loggerStaticFilteringFinderSentence1": {
-    "message": "Staattinen suodatus {{filter}} löytyi:",
-    "description": "Below this sentence, the filter lists in which the filter was found"
+    "message": "Staattinen suodatus <code>{{filter}}</code> löytyi:",
+    "description": "Below this sentence, the filter list(s) in which the filter was found"
+  },
+  "loggerStaticFilteringFinderSentence2": {
+    "message": "Staattista suodatinta <code>{{filter}}</code> ei löytynyt miltään tällä hetkellä käytössä olevalta suodatinlistalta",
+    "description": "Message to show when a filter cannot be found in any filter lists"
   },
   "aboutChangelog": {
     "message": "Muutosloki",

--- a/src/_locales/fil/messages.json
+++ b/src/_locales/fil/messages.json
@@ -608,8 +608,12 @@
     "description": "Used in the static filtering wizard"
   },
   "loggerStaticFilteringFinderSentence1": {
-    "message": "Static filter {{filter}} found in:",
-    "description": "Below this sentence, the filter lists in which the filter was found"
+    "message": "Static filter <code>{{filter}}</code> found in:",
+    "description": "Below this sentence, the filter list(s) in which the filter was found"
+  },
+  "loggerStaticFilteringFinderSentence2": {
+    "message": "Static filter could not be found in any of the currently enabled filter lists",
+    "description": "Message to show when a filter cannot be found in any filter lists"
   },
   "aboutChangelog": {
     "message": "Change log",

--- a/src/_locales/fr/messages.json
+++ b/src/_locales/fr/messages.json
@@ -608,8 +608,12 @@
     "description": "Used in the static filtering wizard"
   },
   "loggerStaticFilteringFinderSentence1": {
-    "message": "Filtre statique {{filter}} trouvé dans :",
-    "description": "Below this sentence, the filter lists in which the filter was found"
+    "message": "Filtre statique <code>{{filter}}</code> trouvé dans :",
+    "description": "Below this sentence, the filter list(s) in which the filter was found"
+  },
+  "loggerStaticFilteringFinderSentence2": {
+    "message": "Filtre statique introuvable parmi les listes de filtre actives",
+    "description": "Message to show when a filter cannot be found in any filter lists"
   },
   "aboutChangelog": {
     "message": "Journal des changements (en Anglais)",

--- a/src/_locales/fy/messages.json
+++ b/src/_locales/fy/messages.json
@@ -608,8 +608,12 @@
     "description": "Used in the static filtering wizard"
   },
   "loggerStaticFilteringFinderSentence1": {
-    "message": "Statysk filter {{filter}} fûn yn:",
-    "description": "Below this sentence, the filter lists in which the filter was found"
+    "message": "Statysk filter <code>{{filter}}</code> fûn yn:",
+    "description": "Below this sentence, the filter list(s) in which the filter was found"
+  },
+  "loggerStaticFilteringFinderSentence2": {
+    "message": "Statysk filter koe net yn ien fan de op dit stuit ynskeakele filterlisten fûn wurde",
+    "description": "Message to show when a filter cannot be found in any filter lists"
   },
   "aboutChangelog": {
     "message": "Wizigingenlochboek",

--- a/src/_locales/gl/messages.json
+++ b/src/_locales/gl/messages.json
@@ -608,8 +608,12 @@
     "description": "Used in the static filtering wizard"
   },
   "loggerStaticFilteringFinderSentence1": {
-    "message": "Filtro estático {{filter}}atopado en:",
-    "description": "Below this sentence, the filter lists in which the filter was found"
+    "message": "Filtro estático <code>{{filter}}</code>atopado en:",
+    "description": "Below this sentence, the filter list(s) in which the filter was found"
+  },
+  "loggerStaticFilteringFinderSentence2": {
+    "message": "Non atopamos filtro estático <code>{{filter}}</code> en ningunha das listas de filtros activas",
+    "description": "Message to show when a filter cannot be found in any filter lists"
   },
   "aboutChangelog": {
     "message": "Rexistro de cambios",

--- a/src/_locales/he/messages.json
+++ b/src/_locales/he/messages.json
@@ -608,8 +608,12 @@
     "description": "Used in the static filtering wizard"
   },
   "loggerStaticFilteringFinderSentence1": {
-    "message": "המסנן הסטאטי {{filter}} נמצא ב:",
-    "description": "Below this sentence, the filter lists in which the filter was found"
+    "message": "המסנן הסטאטי <code>{{filter}}</code> נמצא ב:",
+    "description": "Below this sentence, the filter list(s) in which the filter was found"
+  },
+  "loggerStaticFilteringFinderSentence2": {
+    "message": "המסנן הסטאטי לא נמצא בשום אחת מרשימות המסננים המופעלות כרגע",
+    "description": "Message to show when a filter cannot be found in any filter lists"
   },
   "aboutChangelog": {
     "message": "רשימת שינויים",

--- a/src/_locales/hi/messages.json
+++ b/src/_locales/hi/messages.json
@@ -608,8 +608,12 @@
     "description": "Used in the static filtering wizard"
   },
   "loggerStaticFilteringFinderSentence1": {
-    "message": "Static filter {{filter}} found in:",
-    "description": "Below this sentence, the filter lists in which the filter was found"
+    "message": "<code>{{filter}}</code> में पाया गया स्थिर फ़िल्टर",
+    "description": "Below this sentence, the filter list(s) in which the filter was found"
+  },
+  "loggerStaticFilteringFinderSentence2": {
+    "message": "फिलहाल चालू की गई हुई कोई भी फिल्टर्स सूची में स्थिर फिल्टर नहीं मिल पाया",
+    "description": "Message to show when a filter cannot be found in any filter lists"
   },
   "aboutChangelog": {
     "message": "परिवर्तन सूची",

--- a/src/_locales/hr/messages.json
+++ b/src/_locales/hr/messages.json
@@ -608,8 +608,12 @@
     "description": "Used in the static filtering wizard"
   },
   "loggerStaticFilteringFinderSentence1": {
-    "message": "Statični filter {{filter}} pronađen u:",
-    "description": "Below this sentence, the filter lists in which the filter was found"
+    "message": "Statični filter <code>{{filter}}</code> pronađen u:",
+    "description": "Below this sentence, the filter list(s) in which the filter was found"
+  },
+  "loggerStaticFilteringFinderSentence2": {
+    "message": "Statični filter nije pronađen u trenutno uključenim listama filtera",
+    "description": "Message to show when a filter cannot be found in any filter lists"
   },
   "aboutChangelog": {
     "message": "Popis promjena",

--- a/src/_locales/hu/messages.json
+++ b/src/_locales/hu/messages.json
@@ -608,8 +608,12 @@
     "description": "Used in the static filtering wizard"
   },
   "loggerStaticFilteringFinderSentence1": {
-    "message": "Statikus filter, amiben {{filter}} benne van:",
-    "description": "Below this sentence, the filter lists in which the filter was found"
+    "message": "Statikus filter, amiben <code>{{filter}}</code> benne van:",
+    "description": "Below this sentence, the filter list(s) in which the filter was found"
+  },
+  "loggerStaticFilteringFinderSentence2": {
+    "message": "A statikus szűrő <code>{{filter}}</code> nem található az aktuálisan engedélyezett szűrőlisták egyikében sem",
+    "description": "Message to show when a filter cannot be found in any filter lists"
   },
   "aboutChangelog": {
     "message": "Változások listája",

--- a/src/_locales/id/messages.json
+++ b/src/_locales/id/messages.json
@@ -608,8 +608,12 @@
     "description": "Used in the static filtering wizard"
   },
   "loggerStaticFilteringFinderSentence1": {
-    "message": "Filter statis {{filter}} ditemukan di dalam:",
-    "description": "Below this sentence, the filter lists in which the filter was found"
+    "message": "Filter statis <code>{{filter}}</code> ditemukan di dalam:",
+    "description": "Below this sentence, the filter list(s) in which the filter was found"
+  },
+  "loggerStaticFilteringFinderSentence2": {
+    "message": "Filter statis tidak dapat ditemukan di semua daftar filter yang aktif saat ini",
+    "description": "Message to show when a filter cannot be found in any filter lists"
   },
   "aboutChangelog": {
     "message": "Catatan perubahan",

--- a/src/_locales/it/messages.json
+++ b/src/_locales/it/messages.json
@@ -608,8 +608,12 @@
     "description": "Used in the static filtering wizard"
   },
   "loggerStaticFilteringFinderSentence1": {
-    "message": "Filtro statico {{filter}} trovato in:",
-    "description": "Below this sentence, the filter lists in which the filter was found"
+    "message": "Filtro statico <code>{{filter}}</code> trovato in:",
+    "description": "Below this sentence, the filter list(s) in which the filter was found"
+  },
+  "loggerStaticFilteringFinderSentence2": {
+    "message": "Non è stato possibile trovare il filtro statico <code>{{filter}}</code> in nessun filtro di terze parti attualmente abilitato",
+    "description": "Message to show when a filter cannot be found in any filter lists"
   },
   "aboutChangelog": {
     "message": "Change log",

--- a/src/_locales/ja/messages.json
+++ b/src/_locales/ja/messages.json
@@ -608,8 +608,12 @@
     "description": "Used in the static filtering wizard"
   },
   "loggerStaticFilteringFinderSentence1": {
-    "message": "静的フィルター {{filter}} が見つかりました:",
-    "description": "Below this sentence, the filter lists in which the filter was found"
+    "message": "静的フィルター <code>{{filter}}</code> が見つかりました:",
+    "description": "Below this sentence, the filter list(s) in which the filter was found"
+  },
+  "loggerStaticFilteringFinderSentence2": {
+    "message": "現在 有効にしているフィルターの中には、静的フィルター <code>{{filter}}</code> はありません",
+    "description": "Message to show when a filter cannot be found in any filter lists"
   },
   "aboutChangelog": {
     "message": "バージョン更新履歴 (Change log)",

--- a/src/_locales/ka/messages.json
+++ b/src/_locales/ka/messages.json
@@ -608,8 +608,12 @@
     "description": "Used in the static filtering wizard"
   },
   "loggerStaticFilteringFinderSentence1": {
-    "message": "მუდმივი ფილტრი {{filter}} ნაპოვნია სიაში:",
-    "description": "Below this sentence, the filter lists in which the filter was found"
+    "message": "მუდმივი ფილტრი <code>{{filter}}</code> ნაპოვნია სიაში:",
+    "description": "Below this sentence, the filter list(s) in which the filter was found"
+  },
+  "loggerStaticFilteringFinderSentence2": {
+    "message": "მუდმივი ფილტრი <code>{{filter}}</code> ვერ მოიძებნა ამჟამად გამოყენებულ ფილტრებს შორის",
+    "description": "Message to show when a filter cannot be found in any filter lists"
   },
   "aboutChangelog": {
     "message": "ცვლილებათა ჟურნალი",

--- a/src/_locales/kk/messages.json
+++ b/src/_locales/kk/messages.json
@@ -608,8 +608,12 @@
     "description": "Used in the static filtering wizard"
   },
   "loggerStaticFilteringFinderSentence1": {
-    "message": "Static filter {{filter}} found in:",
-    "description": "Below this sentence, the filter lists in which the filter was found"
+    "message": "Static filter <code>{{filter}}</code> found in:",
+    "description": "Below this sentence, the filter list(s) in which the filter was found"
+  },
+  "loggerStaticFilteringFinderSentence2": {
+    "message": "Static filter could not be found in any of the currently enabled filter lists",
+    "description": "Message to show when a filter cannot be found in any filter lists"
   },
   "aboutChangelog": {
     "message": "Change log",

--- a/src/_locales/kn/messages.json
+++ b/src/_locales/kn/messages.json
@@ -608,8 +608,12 @@
     "description": "Used in the static filtering wizard"
   },
   "loggerStaticFilteringFinderSentence1": {
-    "message": "Static filter {{filter}} found in:",
-    "description": "Below this sentence, the filter lists in which the filter was found"
+    "message": "Static filter <code>{{filter}}</code> found in:",
+    "description": "Below this sentence, the filter list(s) in which the filter was found"
+  },
+  "loggerStaticFilteringFinderSentence2": {
+    "message": "Static filter could not be found in any of the currently enabled filter lists",
+    "description": "Message to show when a filter cannot be found in any filter lists"
   },
   "aboutChangelog": {
     "message": "Change log",

--- a/src/_locales/ko/messages.json
+++ b/src/_locales/ko/messages.json
@@ -608,8 +608,12 @@
     "description": "Used in the static filtering wizard"
   },
   "loggerStaticFilteringFinderSentence1": {
-    "message": "{{filter}} 에서 찾은 고정 필터:",
-    "description": "Below this sentence, the filter lists in which the filter was found"
+    "message": "<code>{{filter}}</code> 에서 찾은 고정 필터:",
+    "description": "Below this sentence, the filter list(s) in which the filter was found"
+  },
+  "loggerStaticFilteringFinderSentence2": {
+    "message": "활성화된 정적 필터 목록에서 <code>{{filter}}</code>를 찾지 못했습니다",
+    "description": "Message to show when a filter cannot be found in any filter lists"
   },
   "aboutChangelog": {
     "message": "변경사항",

--- a/src/_locales/lt/messages.json
+++ b/src/_locales/lt/messages.json
@@ -608,8 +608,12 @@
     "description": "Used in the static filtering wizard"
   },
   "loggerStaticFilteringFinderSentence1": {
-    "message": "Statinis filtras {{filter}} rastas:",
-    "description": "Below this sentence, the filter lists in which the filter was found"
+    "message": "Statinis filtras <code>{{filter}}</code> rastas:",
+    "description": "Below this sentence, the filter list(s) in which the filter was found"
+  },
+  "loggerStaticFilteringFinderSentence2": {
+    "message": "Statinis filtras <code>{{filter}}</code> nerastas jokiame dabar įjungtame filtrų sąraše",
+    "description": "Message to show when a filter cannot be found in any filter lists"
   },
   "aboutChangelog": {
     "message": "Pakeitimų žurnalas",

--- a/src/_locales/lv/messages.json
+++ b/src/_locales/lv/messages.json
@@ -608,8 +608,12 @@
     "description": "Used in the static filtering wizard"
   },
   "loggerStaticFilteringFinderSentence1": {
-    "message": "Statiskais filtrs {{filter}} atrasts:",
-    "description": "Below this sentence, the filter lists in which the filter was found"
+    "message": "Statiskais filtrs <code>{{filter}}</code> atrasts:",
+    "description": "Below this sentence, the filter list(s) in which the filter was found"
+  },
+  "loggerStaticFilteringFinderSentence2": {
+    "message": "Static filter could not be found in any of the currently enabled filter lists",
+    "description": "Message to show when a filter cannot be found in any filter lists"
   },
   "aboutChangelog": {
     "message": "Izmaiņu žurnāls",

--- a/src/_locales/ml/messages.json
+++ b/src/_locales/ml/messages.json
@@ -608,8 +608,12 @@
     "description": "Used in the static filtering wizard"
   },
   "loggerStaticFilteringFinderSentence1": {
-    "message": "സ്റ്റാറ്റിക് ഫില്‍ട്ടര്‍ {{filter}} ഇതില്‍ കണ്ടെത്തി:",
-    "description": "Below this sentence, the filter lists in which the filter was found"
+    "message": "സ്റ്റാറ്റിക് ഫില്‍ട്ടര്‍ <code>{{filter}}</code> ഇതില്‍ കണ്ടെത്തി:",
+    "description": "Below this sentence, the filter list(s) in which the filter was found"
+  },
+  "loggerStaticFilteringFinderSentence2": {
+    "message": "നിലവിൽ പ്രവർത്തനക്ഷമമാക്കിയ ഏതെങ്കിലും ഫിൽട്ടർ ലിസ്റ്റുകളിൽ സ്റ്റാറ്റിക് ഫിൽട്ടർ കണ്ടെത്താൻ കഴിഞ്ഞില്ല",
+    "description": "Message to show when a filter cannot be found in any filter lists"
   },
   "aboutChangelog": {
     "message": "മാറ്റങ്ങളുടെ ലോഗ്",

--- a/src/_locales/mr/messages.json
+++ b/src/_locales/mr/messages.json
@@ -608,8 +608,12 @@
     "description": "Used in the static filtering wizard"
   },
   "loggerStaticFilteringFinderSentence1": {
-    "message": "Static filter {{filter}} found in:",
-    "description": "Below this sentence, the filter lists in which the filter was found"
+    "message": "Static filter <code>{{filter}}</code> found in:",
+    "description": "Below this sentence, the filter list(s) in which the filter was found"
+  },
+  "loggerStaticFilteringFinderSentence2": {
+    "message": "Static filter could not be found in any of the currently enabled filter lists",
+    "description": "Message to show when a filter cannot be found in any filter lists"
   },
   "aboutChangelog": {
     "message": "बदल नोंदी",

--- a/src/_locales/ms/messages.json
+++ b/src/_locales/ms/messages.json
@@ -608,8 +608,12 @@
     "description": "Used in the static filtering wizard"
   },
   "loggerStaticFilteringFinderSentence1": {
-    "message": "Static filter {{filter}} found in:",
-    "description": "Below this sentence, the filter lists in which the filter was found"
+    "message": "Penapis statik <code> {{filter}} </code> terdapat di:",
+    "description": "Below this sentence, the filter list(s) in which the filter was found"
+  },
+  "loggerStaticFilteringFinderSentence2": {
+    "message": "Penapis statik tidak dapat dijumpai dalam daftar penapis yang diaktifkan sekarang",
+    "description": "Message to show when a filter cannot be found in any filter lists"
   },
   "aboutChangelog": {
     "message": "Catatan perubahan",

--- a/src/_locales/nb/messages.json
+++ b/src/_locales/nb/messages.json
@@ -608,8 +608,12 @@
     "description": "Used in the static filtering wizard"
   },
   "loggerStaticFilteringFinderSentence1": {
-    "message": "Statisk filter {{filter}} funnet i:",
-    "description": "Below this sentence, the filter lists in which the filter was found"
+    "message": "Statisk filter <code>{{filter}}</code> funnet i:",
+    "description": "Below this sentence, the filter list(s) in which the filter was found"
+  },
+  "loggerStaticFilteringFinderSentence2": {
+    "message": "Statisk filter ble ikke funnet i noen av filterlistene som er aktiverte nå",
+    "description": "Message to show when a filter cannot be found in any filter lists"
   },
   "aboutChangelog": {
     "message": "Endringslogg",

--- a/src/_locales/nl/messages.json
+++ b/src/_locales/nl/messages.json
@@ -608,8 +608,12 @@
     "description": "Used in the static filtering wizard"
   },
   "loggerStaticFilteringFinderSentence1": {
-    "message": "Statisch filter {{filter}} gevonden in:",
-    "description": "Below this sentence, the filter lists in which the filter was found"
+    "message": "Statisch filter <code>{{filter}}</code> gevonden in:",
+    "description": "Below this sentence, the filter list(s) in which the filter was found"
+  },
+  "loggerStaticFilteringFinderSentence2": {
+    "message": "Statisch filter kon niet in een van de momenteel ingeschakelde filterlijsten worden gevonden",
+    "description": "Message to show when a filter cannot be found in any filter lists"
   },
   "aboutChangelog": {
     "message": "Wijzigingenlogboek",

--- a/src/_locales/pl/messages.json
+++ b/src/_locales/pl/messages.json
@@ -608,8 +608,12 @@
     "description": "Used in the static filtering wizard"
   },
   "loggerStaticFilteringFinderSentence1": {
-    "message": "Filtr statyczny {{filter}} znajdujący się w:",
-    "description": "Below this sentence, the filter lists in which the filter was found"
+    "message": "Filtr statyczny <code>{{filter}}</code> znajdujący się w:",
+    "description": "Below this sentence, the filter list(s) in which the filter was found"
+  },
+  "loggerStaticFilteringFinderSentence2": {
+    "message": "Filtr statyczny nie został znaleziony w aktualnie włączonych listach filtrów",
+    "description": "Message to show when a filter cannot be found in any filter lists"
   },
   "aboutChangelog": {
     "message": "Dziennik zmian",

--- a/src/_locales/pt_BR/messages.json
+++ b/src/_locales/pt_BR/messages.json
@@ -608,8 +608,12 @@
     "description": "Used in the static filtering wizard"
   },
   "loggerStaticFilteringFinderSentence1": {
-    "message": "Filtro estático {{filter}} encontrado em:",
-    "description": "Below this sentence, the filter lists in which the filter was found"
+    "message": "Filtro estático <code>{{filter}}</code> encontrado em:",
+    "description": "Below this sentence, the filter list(s) in which the filter was found"
+  },
+  "loggerStaticFilteringFinderSentence2": {
+    "message": "O filtro estático <code>{{filter}}</code> não foi encontrado em nenhuma das listas de filtros ativadas no momento",
+    "description": "Message to show when a filter cannot be found in any filter lists"
   },
   "aboutChangelog": {
     "message": "Registro de alterações",

--- a/src/_locales/pt_PT/messages.json
+++ b/src/_locales/pt_PT/messages.json
@@ -608,8 +608,12 @@
     "description": "Used in the static filtering wizard"
   },
   "loggerStaticFilteringFinderSentence1": {
-    "message": "Filtro estático {{filter}} encontrado em:",
-    "description": "Below this sentence, the filter lists in which the filter was found"
+    "message": "Filtro estático <code>{{filter}}</code> encontrado em:",
+    "description": "Below this sentence, the filter list(s) in which the filter was found"
+  },
+  "loggerStaticFilteringFinderSentence2": {
+    "message": "O filtro estático não pôde ser encontrado em quaisquer das listas de filtros ativadas atualmente",
+    "description": "Message to show when a filter cannot be found in any filter lists"
   },
   "aboutChangelog": {
     "message": "Registo de alterações",

--- a/src/_locales/ro/messages.json
+++ b/src/_locales/ro/messages.json
@@ -608,8 +608,12 @@
     "description": "Used in the static filtering wizard"
   },
   "loggerStaticFilteringFinderSentence1": {
-    "message": "Filtru static {{filter}} găsit în:",
-    "description": "Below this sentence, the filter lists in which the filter was found"
+    "message": "Filtrul static <code>{{filter}}</code> găsit în:",
+    "description": "Below this sentence, the filter list(s) in which the filter was found"
+  },
+  "loggerStaticFilteringFinderSentence2": {
+    "message": "Filtrul static <code>{{filter}}</code> nu se găsește în niciuna dintre listele de filtre activate",
+    "description": "Message to show when a filter cannot be found in any filter lists"
   },
   "aboutChangelog": {
     "message": "Jurnalul de modificări",

--- a/src/_locales/ru/messages.json
+++ b/src/_locales/ru/messages.json
@@ -608,8 +608,12 @@
     "description": "Used in the static filtering wizard"
   },
   "loggerStaticFilteringFinderSentence1": {
-    "message": "Статический фильтр {{filter}} найден в:",
-    "description": "Below this sentence, the filter lists in which the filter was found"
+    "message": "Статический фильтр <code>{{filter}}</code> найден в:",
+    "description": "Below this sentence, the filter list(s) in which the filter was found"
+  },
+  "loggerStaticFilteringFinderSentence2": {
+    "message": "Статический фильтр не найден ни в одном списке фильтров, включенных в данный момент",
+    "description": "Message to show when a filter cannot be found in any filter lists"
   },
   "aboutChangelog": {
     "message": "Список изменений",

--- a/src/_locales/sk/messages.json
+++ b/src/_locales/sk/messages.json
@@ -608,8 +608,12 @@
     "description": "Used in the static filtering wizard"
   },
   "loggerStaticFilteringFinderSentence1": {
-    "message": "Statický filter {{filter}} bol nájdený v:",
-    "description": "Below this sentence, the filter lists in which the filter was found"
+    "message": "Statický filter <code>{{filter}}</code> bol nájdený v:",
+    "description": "Below this sentence, the filter list(s) in which the filter was found"
+  },
+  "loggerStaticFilteringFinderSentence2": {
+    "message": "Statický filter <code>{{filter}}</code> sa nepodarilo nájsť v žiadnom momentálne povolenom zozname filtrov",
+    "description": "Message to show when a filter cannot be found in any filter lists"
   },
   "aboutChangelog": {
     "message": "Zoznam zmien",

--- a/src/_locales/sl/messages.json
+++ b/src/_locales/sl/messages.json
@@ -608,8 +608,12 @@
     "description": "Used in the static filtering wizard"
   },
   "loggerStaticFilteringFinderSentence1": {
-    "message": "Statičen filter {{filter}} najden v:",
-    "description": "Below this sentence, the filter lists in which the filter was found"
+    "message": "Statičen filter <code>{{filter}}</code> najden v:",
+    "description": "Below this sentence, the filter list(s) in which the filter was found"
+  },
+  "loggerStaticFilteringFinderSentence2": {
+    "message": "Statični filter <code>{{filter}}</code> ni bil najden v nobenem izmed trenutno izbranih seznamov",
+    "description": "Message to show when a filter cannot be found in any filter lists"
   },
   "aboutChangelog": {
     "message": "Dnevnik sprememb",

--- a/src/_locales/sq/messages.json
+++ b/src/_locales/sq/messages.json
@@ -608,8 +608,12 @@
     "description": "Used in the static filtering wizard"
   },
   "loggerStaticFilteringFinderSentence1": {
-    "message": "Filtri statik {{filter}} gjendet në:",
-    "description": "Below this sentence, the filter lists in which the filter was found"
+    "message": "Filtri statik <code>{{filter}}</code> gjendet në:",
+    "description": "Below this sentence, the filter list(s) in which the filter was found"
+  },
+  "loggerStaticFilteringFinderSentence2": {
+    "message": "Nuk u gjet filtri statik në asnjërën prej listave aktive",
+    "description": "Message to show when a filter cannot be found in any filter lists"
   },
   "aboutChangelog": {
     "message": "Ditari i ndryshimeve",

--- a/src/_locales/sr/messages.json
+++ b/src/_locales/sr/messages.json
@@ -608,8 +608,12 @@
     "description": "Used in the static filtering wizard"
   },
   "loggerStaticFilteringFinderSentence1": {
-    "message": "Статички филтер {{filter}} пронађен у:",
-    "description": "Below this sentence, the filter lists in which the filter was found"
+    "message": "Статички филтер <code>{{filter}}</code> пронађен у:",
+    "description": "Below this sentence, the filter list(s) in which the filter was found"
+  },
+  "loggerStaticFilteringFinderSentence2": {
+    "message": "Статички филтер није могуће пронаћи нити у једној тренутно омогућеној листи филтера",
+    "description": "Message to show when a filter cannot be found in any filter lists"
   },
   "aboutChangelog": {
     "message": "Евиденција промена",

--- a/src/_locales/sv/messages.json
+++ b/src/_locales/sv/messages.json
@@ -608,8 +608,12 @@
     "description": "Used in the static filtering wizard"
   },
   "loggerStaticFilteringFinderSentence1": {
-    "message": "Det statiska filtret {{filter}} hittades i:",
-    "description": "Below this sentence, the filter lists in which the filter was found"
+    "message": "Det statiska filtret <code>{{filter}}</code> hittades i:",
+    "description": "Below this sentence, the filter list(s) in which the filter was found"
+  },
+  "loggerStaticFilteringFinderSentence2": {
+    "message": "Statiskt filter kunde inte hittas i någon av de aktuella aktiverade filterlistorna",
+    "description": "Message to show when a filter cannot be found in any filter lists"
   },
   "aboutChangelog": {
     "message": "Ändringslogg",

--- a/src/_locales/ta/messages.json
+++ b/src/_locales/ta/messages.json
@@ -608,8 +608,12 @@
     "description": "Used in the static filtering wizard"
   },
   "loggerStaticFilteringFinderSentence1": {
-    "message": "Static filter {{filter}} found in:",
-    "description": "Below this sentence, the filter lists in which the filter was found"
+    "message": "நிலையான வடிப்பான் <code> {{வடிகட்டி}} </ குறியீடு> இதில் காணப்படுகிறது:",
+    "description": "Below this sentence, the filter list(s) in which the filter was found"
+  },
+  "loggerStaticFilteringFinderSentence2": {
+    "message": "தற்போது இயக்கப்பட்ட வடிகட்டி பட்டியல்களில் நிலையான வடிப்பானைக் கண்டுபிடிக்க முடியவில்லை",
+    "description": "Message to show when a filter cannot be found in any filter lists"
   },
   "aboutChangelog": {
     "message": "நிரல் மாற்றம் மற்றும் வெளியீடுகளின் பதிவு",

--- a/src/_locales/te/messages.json
+++ b/src/_locales/te/messages.json
@@ -608,8 +608,12 @@
     "description": "Used in the static filtering wizard"
   },
   "loggerStaticFilteringFinderSentence1": {
-    "message": "నిశ్చలాత్మక వడపోత అయిన {{filter}} క్రింది వాటిలో కలదు:",
-    "description": "Below this sentence, the filter lists in which the filter was found"
+    "message": "నిశ్చలాత్మక ఫిల్టర్ అయిన <code>{{filter}}</code> క్రింది వాటిలో కలదు:",
+    "description": "Below this sentence, the filter list(s) in which the filter was found"
+  },
+  "loggerStaticFilteringFinderSentence2": {
+    "message": "నిశ్చలాత్మక ఫిల్టర్ అయిన <code>{{filter}}</code> ప్రస్తుతం ఉత్తేజపరిచిన ఫిల్టర్ జాబితాలలో కనుగొనబడలేదు",
+    "description": "Message to show when a filter cannot be found in any filter lists"
   },
   "aboutChangelog": {
     "message": "మార్పుల సంచిక",

--- a/src/_locales/tr/messages.json
+++ b/src/_locales/tr/messages.json
@@ -608,8 +608,12 @@
     "description": "Used in the static filtering wizard"
   },
   "loggerStaticFilteringFinderSentence1": {
-    "message": "Statik süzgecin {{filter}} bulunduğu listeler:",
-    "description": "Below this sentence, the filter lists in which the filter was found"
+    "message": "Statik filtrenin <code>{{filter}}</code> bulunduğu listeler:",
+    "description": "Below this sentence, the filter list(s) in which the filter was found"
+  },
+  "loggerStaticFilteringFinderSentence2": {
+    "message": "Statik filtre, şu anda etkin olan filtre listelerinde bulunamadı",
+    "description": "Message to show when a filter cannot be found in any filter lists"
   },
   "aboutChangelog": {
     "message": "Değişiklikler",

--- a/src/_locales/uk/messages.json
+++ b/src/_locales/uk/messages.json
@@ -608,8 +608,12 @@
     "description": "Used in the static filtering wizard"
   },
   "loggerStaticFilteringFinderSentence1": {
-    "message": "Статичний фільтр {{filter}} знайдено в:",
-    "description": "Below this sentence, the filter lists in which the filter was found"
+    "message": "Статичний фільтр <code>{{filter}}</code> знайден у:",
+    "description": "Below this sentence, the filter list(s) in which the filter was found"
+  },
+  "loggerStaticFilteringFinderSentence2": {
+    "message": "Статичний фільтр <code>{{filter}}</code> не знайдений в жодному списку увімкнених у даний момент фільтрів",
+    "description": "Message to show when a filter cannot be found in any filter lists"
   },
   "aboutChangelog": {
     "message": "Журнал змін",

--- a/src/_locales/vi/messages.json
+++ b/src/_locales/vi/messages.json
@@ -608,8 +608,12 @@
     "description": "Used in the static filtering wizard"
   },
   "loggerStaticFilteringFinderSentence1": {
-    "message": "Bộ lọc tĩnh {{filter}} phát hiện trong:",
-    "description": "Below this sentence, the filter lists in which the filter was found"
+    "message": "Bộ lọc tĩnh <code>{{filter}}</code> phát hiện trong:",
+    "description": "Below this sentence, the filter list(s) in which the filter was found"
+  },
+  "loggerStaticFilteringFinderSentence2": {
+    "message": "Bộ lọc tĩnh <code>{{filter}}</code> không thể tìm thấy trong bất kỳ danh sách bộ lọc hiện được bật nào",
+    "description": "Message to show when a filter cannot be found in any filter lists"
   },
   "aboutChangelog": {
     "message": "Thay đổi",

--- a/src/_locales/zh_CN/messages.json
+++ b/src/_locales/zh_CN/messages.json
@@ -608,8 +608,12 @@
     "description": "Used in the static filtering wizard"
   },
   "loggerStaticFilteringFinderSentence1": {
-    "message": "静态规则 {{filter}} 被包含于:",
-    "description": "Below this sentence, the filter lists in which the filter was found"
+    "message": "静态规则 <code>{{filter}}</code> 被包含于：",
+    "description": "Below this sentence, the filter list(s) in which the filter was found"
+  },
+  "loggerStaticFilteringFinderSentence2": {
+    "message": "无法在当前启用的任何过滤规则列表中找到静态规则",
+    "description": "Message to show when a filter cannot be found in any filter lists"
   },
   "aboutChangelog": {
     "message": "更新日志",

--- a/src/_locales/zh_TW/messages.json
+++ b/src/_locales/zh_TW/messages.json
@@ -608,8 +608,12 @@
     "description": "Used in the static filtering wizard"
   },
   "loggerStaticFilteringFinderSentence1": {
-    "message": "在下列清單中找到靜態過濾器 {{filter}}:",
-    "description": "Below this sentence, the filter lists in which the filter was found"
+    "message": "在下列清單中找到靜態過濾規則 <code>{{filter}}</code>：",
+    "description": "Below this sentence, the filter list(s) in which the filter was found"
+  },
+  "loggerStaticFilteringFinderSentence2": {
+    "message": "無法在當前啟用的任何過濾清單中找到靜態過濾規則",
+    "description": "Message to show when a filter cannot be found in any filter lists"
   },
   "aboutChangelog": {
     "message": "更新日誌",

--- a/src/css/logger-ui.css
+++ b/src/css/logger-ui.css
@@ -599,6 +599,18 @@ body.colorBlind  #netFilteringDialog .dialog > div.containers > div.dynamic tr.e
 #filterFinderDialog .dialog ul {
     font-size: larger;
     }
+#filterFinderDialog .filterFinderListEntry a {
+    text-decoration: none;
+    }
+#filterFinderDialog .filterFinderListEntry a.fa {
+    opacity: 0.8;
+    }
+#filterFinderDialog .filterFinderListEntry a.fa:hover {
+    opacity: 1;
+    }
+#filterFinderDialog .filterFinderListEntry a[href=""]:nth-of-type(2) {
+    display: none;
+    }
 #filterFinderDialog .dialog > *:first-child {
     margin-top: 0;
     }

--- a/src/js/logger-ui.js
+++ b/src/js/logger-ui.js
@@ -1,7 +1,7 @@
 /*******************************************************************************
 
     uBlock Origin - a browser extension to block requests.
-    Copyright (C) 2015-2018 Raymond Hill
+    Copyright (C) 2015-present Raymond Hill
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -21,11 +21,11 @@
 
 /* global uDom */
 
+'use strict';
+
 /******************************************************************************/
 
 (function() {
-
-'use strict';
 
 /******************************************************************************/
 
@@ -1237,21 +1237,18 @@ var netFilteringManager = (function() {
 /******************************************************************************/
 
 var reverseLookupManager = (function() {
-    var reSentence1 = /\{\{filter\}\}/g;
-    var sentence1Template = vAPI.i18n('loggerStaticFilteringFinderSentence1');
-    var filterFinderDialog = uDom.nodeFromId('filterFinderDialog');
+    let filterFinderDialog = uDom.nodeFromId('filterFinderDialog');
+    let rawFilter = '';
 
-    var removeAllChildren = function(node) {
+    let removeAllChildren = function(node) {
         while ( node.firstChild ) {
             node.removeChild(node.firstChild);
         }
     };
 
-    var onClick = function(ev) {
-        var target = ev.target;
-
-        // click outside the dialog proper
-        if ( target.classList.contains('modalDialog') ) {
+    // Clicking outside the dialog will close the dialog
+    let onClick = function(ev) {
+        if ( ev.target.classList.contains('modalDialog') ) {
             toggleOff();
             return;
         }
@@ -1259,42 +1256,30 @@ var reverseLookupManager = (function() {
         ev.stopPropagation();
     };
 
-    var nodeFromFilter = function(filter, lists) {
+    let nodeFromFilter = function(filter, lists) {
         if ( Array.isArray(lists) === false || lists.length === 0 ) {
-            return null;
+            return;
         }
-        var node,
-            p = document.createElement('p');
 
-        reSentence1.lastIndex = 0;
-        var matches = reSentence1.exec(sentence1Template);
-        if ( matches === null ) {
-            node = document.createTextNode(sentence1Template);
-        } else {
-            node = uDom.nodeFromSelector('#filterFinderDialogSentence1 > span').cloneNode(true);
-            node.childNodes[0].textContent = sentence1Template.slice(0, matches.index);
-            // https://github.com/gorhill/uBlock/issues/2753
-            node.childNodes[1].textContent = filter.length <= 1024
-                ? filter
-                : filter.slice(0, 1023) + '…';
-            node.childNodes[2].textContent = sentence1Template.slice(reSentence1.lastIndex);
-        }
-        p.appendChild(node);
+        let p = document.createElement('p');
 
-        var ul = document.createElement('ul');
-        var list, li;
-        for ( var i = 0; i < lists.length; i++ ) {
-            list = lists[i];
-            li = document.createElement('li');
+        vAPI.i18n.safeTemplateToDOM(
+            'loggerStaticFilteringFinderSentence1',
+            { filter: filter },
+            p
+        );
+
+        let ul = document.createElement('ul');
+        for ( let list of lists ) {
+            let li = document.querySelector('#filterFinderListEntry > li')
+                             .cloneNode(true);
+            let a = li.querySelector('a:nth-of-type(1)');
+            a.href += encodeURIComponent(list.assetKey);
+            a.textContent = list.title;
             if ( list.supportURL ) {
-                node = document.createElement('a');
-                node.textContent = list.title;
-                node.setAttribute('href', list.supportURL);
-                node.setAttribute('target', '_blank');
-            } else {
-                node = document.createTextNode(list.title);
+                a = li.querySelector('a:nth-of-type(2)');
+                a.setAttribute('href', list.supportURL);
             }
-            li.appendChild(node);
             ul.appendChild(li);
         }
         p.appendChild(ul);
@@ -1302,30 +1287,37 @@ var reverseLookupManager = (function() {
         return p;
     };
 
-    var reverseLookupDone = function(response) {
-        if ( typeof response !== 'object' ) {
-            return;
+    let reverseLookupDone = function(response) {
+        if ( response instanceof Object === false ) {
+            response = {};
         }
 
-        var dialog = filterFinderDialog.querySelector('.dialog');
+        let dialog = filterFinderDialog.querySelector('.dialog');
         removeAllChildren(dialog);
 
-        for ( var filter in response ) {
-            var p = nodeFromFilter(filter, response[filter]);
-            if ( p === null ) { continue; }
+        for ( let filter in response ) {
+            let p = nodeFromFilter(filter, response[filter]);
+            if ( p === undefined ) { continue; }
             dialog.appendChild(p);
+        }
+
+        // https://github.com/gorhill/uBlock/issues/2179
+        if ( dialog.childElementCount === 0 ) {
+            vAPI.i18n.safeTemplateToDOM(
+                'loggerStaticFilteringFinderSentence2',
+                { filter: rawFilter },
+                dialog
+            );
         }
 
         document.body.appendChild(filterFinderDialog);
         filterFinderDialog.addEventListener('click', onClick, true);
     };
 
-    var toggleOn = function(ev) {
-        var row = ev.target.parentElement;
-        var rawFilter = row.cells[2].textContent;
-        if ( rawFilter === '' ) {
-            return;
-        }
+    let toggleOn = function(ev) {
+        let row = ev.target.parentElement;
+        rawFilter = row.cells[2].textContent;
+        if ( rawFilter === '' ) { return; }
 
         if ( row.classList.contains('cat_net') ) {
             messaging.send(
@@ -1350,9 +1342,10 @@ var reverseLookupManager = (function() {
         }
     };
 
-    var toggleOff = function() {
+    let toggleOff = function() {
         filterFinderDialog.removeEventListener('click', onClick, true);
         document.body.removeChild(filterFinderDialog);
+        rawFilter = '';
     };
 
     return {

--- a/src/js/reverselookup-worker.js
+++ b/src/js/reverselookup-worker.js
@@ -231,6 +231,7 @@ var fromCosmeticFilter = function(details) {
                     response[found] = [];
                 }
                 response[found].push({
+                    assetKey: assetKey,
                     title: entry.title,
                     supportURL: entry.supportURL
                 });

--- a/src/logger-ui.html
+++ b/src/logger-ui.html
@@ -107,13 +107,17 @@
     <div id="filterFinderDialog" class="modalDialog">
         <div class="dialog"></div>
     </div>
+    <ul id="filterFinderListEntry">
+        <li class="filterFinderListEntry">
+            <a href="asset-viewer.html?url=" target="_blank"></a>
+            <a href="" class="fa" target="_blank">&#xf015;</span></li>
+    </ul>
     <div id="cosmeticFilteringDialog" class="modalDialog">
         <div class="dialog">
             <textarea class="cosmeticFilters" value=""></textarea>
             <button id="createCosmeticFilters" class="important" type="button" data-i18n="pickerCreate"></button>
         </div>
     </div>
-    <div id="filterFinderDialogSentence1"><span><span></span><code></code><span></span></span></div>
 </div>
 
 <script src="js/vapi.js"></script>


### PR DESCRIPTION
All is good described in issue description and can be reproduced with for example `ppe.pl` and `EasyList`.

In short when logger is opened and you then disable filterlist which had filter which was in logger, then when you click on that filter, blank message will be displayed, but should be written that `Static filter could not be found in any of the currently enabled filter lists`.